### PR TITLE
Allow password users to run ship init

### DIFF
--- a/api/src/commands/migrate-clusters.ts
+++ b/api/src/commands/migrate-clusters.ts
@@ -70,7 +70,7 @@ async function main(argv): Promise<any> {
       await watchStore.setParent(watch.id!, parentWatch.id!);
     }
 
-    const watchNotifications = await notificationStore.listNotifications(watch.id!);
+    const watchNotifications = await notificationStore.listNotificationsOLD(watch.id!);
 
     for (const watchNotification of watchNotifications) {
       if (watchNotification.pullRequest) {

--- a/api/src/notification/resolvers/notification_mutations.ts
+++ b/api/src/notification/resolvers/notification_mutations.ts
@@ -147,18 +147,9 @@ export function NotificationMutations(stores: any) {
       return result;
     },
 
-    async deleteNotification(root: any, args: DeleteNotificationMutationArgs, context: Context) {
-      const span: jaeger.SpanContext = tracer().startSpan("mutation.deleteNotificaton");
-
-      if(args.isPending) {
-        const notification = await stores.notificationStore.findPendingUserNotification(span.context(), context.session.userId, args.id);
-        await stores.notificationStore.deletePendingNotificationById(span.context(), notification.id!);
-      } else {
-        const notification = await stores.notificationStore.findUserNotification(span.context(), context.session.userId, args.id);
-        await stores.notificationStore.deleteNotification(notification.id!);
-      }
-
-      span.finish();
+    async deleteNotification(root: any, args: any, context: Context) {
+      const notification = await stores.notificationStore.findUserNotification(context.session.userId, args.id);
+      await stores.notificationStore.deleteNotification(notification.id);
       return true;
     }
   }

--- a/api/src/notification/resolvers/notification_queries.ts
+++ b/api/src/notification/resolvers/notification_queries.ts
@@ -27,52 +27,9 @@ export function NotificationQueries(stores: Stores) {
     },
 
     async listNotifications(root: any, args: ListNotificationsQueryArgs, context: Context): Promise<Notification[]> {
-      const span: jaeger.SpanContext = tracer().startSpan("query.getNotifications");
-
       const watch: Watch = await stores.watchStore.findUserWatch(context.session.userId, { id: args.watchId });
       const notifications = await stores.notificationStore.listNotifications(watch.id!);
-      // Not surfacing to UI currently, but optional
-      const pendingNotifications = await stores.notificationStore.listPendingPRNotifications(span.context(), watch.id!);
-      const allNotifications = _.concat(notifications, pendingNotifications);
-
-      const github = new GitHubApi();
-      github.authenticate({
-        type: "token",
-        token: context.getGitHubToken(),
-      });
-
-      // Update PR history
-      allNotifications.map(async notification => {
-        if (notification.pullRequest) {
-          const historyItems = await stores.notificationStore.listPullRequestHistory(span.context(), notification.id!);
-          historyItems.map(async historyItem => {
-            if (historyItem.status === "unknown" || historyItem.status === "pending") {
-              const params: GitHubApi.PullRequestsGetParams = {
-                owner: notification.pullRequest!.org,
-                repo: notification.pullRequest!.repo,
-                number: historyItem.number!,
-              };
-              const { data: pullRequestData } = await github.pullRequests.get(params);
-              let merged = false;
-              if (pullRequestData.state === "closed") {
-                merged = pullRequestData.merged === true;
-              }
-              await stores.notificationStore.updatePullRequestStatus(
-                span.context(),
-                params.owner,
-                params.repo,
-                params.number,
-                pullRequestData.state!,
-                merged,
-              );
-            }
-          });
-        }
-      })
-
-      span.finish();
-
-      return allNotifications;
+      return notifications;
     },
 
     async getNotification(root: any, args: GetNotificationQueryArgs, context: Context): Promise<Notification> {

--- a/worker/pkg/store/user.go
+++ b/worker/pkg/store/user.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship-cluster/worker/pkg/types"
+)
+
+func (s *SQLStore) GetUser(ctx context.Context, userID string) (types.User, error) {
+	githubUser, err := s.GetGitHubUser(ctx, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get github user")
+	}
+
+	if githubUser != nil {
+		return *githubUser, nil
+	}
+
+	passwordUser, err := s.GetPasswordUser(ctx, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get password user")
+	}
+
+	if passwordUser != nil {
+		return *passwordUser, nil
+	}
+
+	return nil, errors.New("unknown user type")
+}
+
+func (s *SQLStore) GetGitHubUser(ctx context.Context, userID string) (*types.GitHubUser, error) {
+	query := `select user_id, username from github_user where user_id = $1`
+	row := s.db.QueryRowContext(ctx, query, userID)
+
+	githubUser := types.GitHubUser{}
+	if err := row.Scan(&githubUser.ID, &githubUser.Username); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
+		return nil, errors.Wrap(err, "scan")
+	}
+
+	return &githubUser, nil
+}
+
+func (s *SQLStore) GetPasswordUser(ctx context.Context, userID string) (*types.PasswordUser, error) {
+	query := `select user_id, email from ship_user_local where user_id = $1`
+	row := s.db.QueryRowContext(ctx, query, userID)
+
+	passwordUser := types.PasswordUser{}
+	if err := row.Scan(&passwordUser.ID, &passwordUser.Email); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
+		return nil, errors.Wrap(err, "scan")
+	}
+
+	return &passwordUser, nil
+}

--- a/worker/pkg/types/github_user.go
+++ b/worker/pkg/types/github_user.go
@@ -1,0 +1,15 @@
+package types
+
+type GitHubUser struct {
+	ID string
+
+	Username string
+}
+
+func (u GitHubUser) GetID() string {
+	return u.ID
+}
+
+func (u GitHubUser) GetUsername() string {
+	return u.Username
+}

--- a/worker/pkg/types/password_user.go
+++ b/worker/pkg/types/password_user.go
@@ -1,0 +1,15 @@
+package types
+
+type PasswordUser struct {
+	ID string
+
+	Email string
+}
+
+func (u PasswordUser) GetID() string {
+	return u.ID
+}
+
+func (u PasswordUser) GetUsername() string {
+	return u.Email
+}

--- a/worker/pkg/types/user.go
+++ b/worker/pkg/types/user.go
@@ -1,0 +1,7 @@
+package types
+
+// User is a shared interface for the different user types
+type User interface {
+	GetID() string
+	GetUsername() string
+}


### PR DESCRIPTION
This leaves some of the previous notifications code in, but renamed to OLD for easier finding later. These are needed for migration in ship cloud.