### PR TITLE
Fix panic when more segments than 3

### DIFF
--- a/worker/pkg/imageworker/version.go
+++ b/worker/pkg/imageworker/version.go
@@ -145,6 +145,9 @@ func (c SemverTagCollection) RemoveLeastSpecific() []*semver.Version {
 
 		isLessSpecific := true
 		for idx, iSegment := range iSegments {
+			if len(jSegments) < idx+1 {
+				break
+			}
 			if iSegment > 0 && jSegments[idx] == 0 {
 				break
 			}

--- a/worker/pkg/imageworker/version_test.go
+++ b/worker/pkg/imageworker/version_test.go
@@ -303,6 +303,11 @@ func TestRemoveLeastSpecific(t *testing.T) {
 			versions:       []string{"0.0.0", "0.0", "0"},
 			expectVersions: []string{"0.0.0"},
 		},
+		{
+			name:           "more segments",
+			versions:       []string{"3.5.1.1", "3.5.1", "4.5.1"},
+			expectVersions: []string{"3.5.1.1", "4.5.1"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
```
panic: runtime error: index out of range

goroutine 165 [running]:
github.com/replicatedcom/ship-cloud-worker/pkg/imageworker.SemverTagCollection.RemoveLeastSpecific(0xc0002684d0, 0xc, 0x26, 0xc0009b4460, 0xc0002684d0, 0xc)
	/go/src/github.com/replicatedcom/ship-cloud-worker/pkg/imageworker/version.go:148 +0x293
github.com/replicatedcom/ship-cloud-worker/pkg/imageworker.(*Worker).checkImage(0xc0006e5890, 0xc000953a60, 0x20, 0x0, 0x0)
	/go/src/github.com/replicatedcom/ship-cloud-worker/pkg/imageworker/worker.go:163 +0x6c4
github.com/replicatedcom/ship-cloud-worker/pkg/imageworker.(*Worker).startPollingDBForImagesNeedingCheck(0xc0006e5890, 0x1f56340, 0xc0000aa030, 0x2, 0x0)
	/go/src/github.com/replicatedcom/ship-cloud-worker/pkg/imageworker/worker.go:89 +0x242
github.com/replicatedcom/ship-cloud-worker/pkg/imageworker.(*Worker).Run.func1(0x1f35c00, 0xc0006e5950, 0xc0006e5890, 0xc000ad88a0)
	/go/src/github.com/replicatedcom/ship-cloud-worker/pkg/imageworker/worker.go:57 +0xf7
created by github.com/replicatedcom/ship-cloud-worker/pkg/imageworker.(*Worker).Run
	/go/src/github.com/replicatedcom/ship-cloud-worker/pkg/imageworker/worker.go:55 +0x454
```