### PR TITLE
[ch20295] GitHub cluster creation bug

### DIFF
--- a/web/src/components/shared/ConfigureGitHubCluster.jsx
+++ b/web/src/components/shared/ConfigureGitHubCluster.jsx
@@ -55,6 +55,16 @@ export class ConfigureGitHub extends React.Component {
     }
   }
 
+  componentDidMount() {
+    const { getGithubUserOrgs } = this.props;
+    if (getGithubUserOrgs && getGithubUserOrgs.installationOrganizations) {
+      const NEW_INSTALLATION_ORG = { login: NEW_ORG_LOGIN };
+      this.setState({
+        orgs: [ NEW_INSTALLATION_ORG, ...getGithubUserOrgs.installationOrganizations.installations ],
+      });
+    }
+  }
+
   populateReposAndBranches = async (integration) => {
     const { owner: orgName, repo: repoName, branch: branchName } =  integration;
     const { data: orgData } = await this.getOrgRepos(orgName);


### PR DESCRIPTION
fix bug that would prevent you from creating two GitHub clusters in a row without a refresh in between