### PR TITLE
set PHP filename to prevent default override

### DIFF
--- a/web/src/Root.jsx
+++ b/web/src/Root.jsx
@@ -44,6 +44,7 @@ if(process.env.NODE_ENV === "production") {
     siteId: 6,
     trackErrors: true,
     jsFilename: "js/",
+    phpFilename: "js/"
   });
   history = piwik.connectToHistory(history);
 }


### PR DESCRIPTION
I feel like an explanation is in order here on what's happening:

If you look at the source of react-piwik - the library sets the phpFilename to `Piwik.php` if it's `undefined`, but it also sets its `trackingUrl` to just the `phpFilename` value, that's why it's the same for `phpFilename` and `jsFilename`.