### PR TITLE
fix copypaste error - worker->operator

### DIFF
--- a/operator/.buildkite/pipeline.yml
+++ b/operator/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
       - if [ ! -z "$GIT_TAG" ]; then buildkite-agent artifact download operator/bin/* . --step test-and-build; fi
       - if [ ! -z "$GIT_TAG" ]; then cp operator/bin/kotsadm-operator operator/deploy/bin/kotsadm-operator; fi
       - if [ ! -z "$GIT_TAG" ]; then chmod +x operator/deploy/bin/kotsadm-operator; fi
-      - if [ ! -z "$GIT_TAG" ]; then make -C worker build-release; fi
+      - if [ ! -z "$GIT_TAG" ]; then make -C operator build-release; fi
 
   # - wait
 


### PR DESCRIPTION
Buildkite push-to-prod steps are failing here:

https://buildkite.com/replicated/kotsadm-operator/builds/130#3358004e-d491-4b99-a73c-478670afb07e

looks like a copy/paste error.