### PR TITLE
Uploading kots

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "simple-oauth2": "^2.2.1",
     "slugify": "^1.3.1",
     "source-map-support": "^0.5.12",
+    "tar": "^4.4.10",
     "tar-stream": "^1.6.2",
     "tmp": "^0.1.0",
     "ts-log-debug": "^4.0.4",

--- a/api/src/controllers/KotsAPI.ts
+++ b/api/src/controllers/KotsAPI.ts
@@ -5,6 +5,9 @@ import { putObject } from "../util/s3";
 import { Params } from "../server/params";
 import path from "path";
 import fs from "fs";
+import * as _ from "lodash";
+import { extractDownstreamNamesFromTarball } from "../util/tar";
+import { Cluster } from "../cluster";
 
 interface CreateAppBody {
   metadata: string;
@@ -22,6 +25,9 @@ export class KotsAPI {
     @BodyParams("") body: CreateAppBody,
     @Req() request: Request,
   ): Promise<any> {
+    // IMPORTANT: this function does not have user-auth and is only usable in
+    // single tenant (on-prem mode right now)
+
     const kotsApp = await request.app.locals.stores.kotsAppStore.createKotsApp(JSON.parse(body.metadata).name);
 
     const params = await Params.getParams();
@@ -30,6 +36,21 @@ export class KotsAPI {
     await putObject(params, objectStorePath, buffer, params.shipOutputBucket);
 
     await request.app.locals.stores.kotsAppStore.createKotsAppVersion(kotsApp.id, 0, "----");
+
+    // we have a local copy of the file now, let's look for downstreams
+    const downstreams = await extractDownstreamNamesFromTarball(buffer);
+    const clusters = await request.app.locals.stores.clusterStore.listAllUsersClusters();
+    for (const downstream of downstreams) {
+      const cluster = _.find(clusters, (c: Cluster) => {
+        return c.title === downstream;
+      });
+
+      if (!cluster) {
+        continue;
+      }
+
+      await request.app.locals.stores.kotsAppStore.createDownstream(kotsApp.id, downstream, cluster.id);
+    }
 
     return {
       uri: `${params.shipApiEndpoint}/app/${kotsApp.slug}`,

--- a/api/src/kots_app/kots_app_store.ts
+++ b/api/src/kots_app/kots_app_store.ts
@@ -10,6 +10,17 @@ import _ from "lodash";
 export class KotsAppStore {
   constructor(private readonly pool: pg.Pool, private readonly params: Params) {}
 
+  async createDownstream(appId: string, downstreamName: string, clusterId: string): Promise<void> {
+    const q = `insert into app_downstream (app_id, downstream_name, cluster_id) values ($1, $2, $3)`;
+    const v = [
+      appId,
+      downstreamName,
+      clusterId,
+    ];
+
+    await this.pool.query(q, v);
+  }
+
   async createKotsAppVersion(id: string, sequence: number, versionLabel: string): Promise<void> {
     const q = `insert into app_version (app_id, sequence, created_at, version_label) values ($1, $2, $3, $4)`;
     const v = [

--- a/api/src/util/tar.ts
+++ b/api/src/util/tar.ts
@@ -1,0 +1,39 @@
+import { Parse as TarParser } from "tar";
+import { PassThrough as PassThroughStream } from "stream";
+import path from "path";
+import * as _ from "lodash";
+
+function bufferToStream(buffer: Buffer): NodeJS.ReadableStream {
+  const stream = new PassThroughStream();
+  stream.end(buffer);
+  return stream;
+}
+
+export function extractDownstreamNamesFromTarball(tarball: Buffer): Promise<string[]> {
+  return new Promise<string[]>((resolve, reject) => {
+    let downstreamNames: string[] = [];
+    const parser = new TarParser({
+      strict: true,
+      filter: (currentPath: string) => {
+        const parts = currentPath.split(path.sep);
+        _.remove(parts, (n) => {
+          return n.length === 0;
+        });
+
+        // the first part is always the name of the directory it was uploaded from
+        if (parts.length === 4) {
+          if (parts[0] === "overlays" && parts[1] === "downstreams" && parts[3] === "kustomization.yaml") {
+            downstreamNames.push(parts[2]);
+          }
+        }
+        return false;
+      },
+    });
+    bufferToStream(tarball)
+      .pipe(parser)
+      .on('end', () => {
+        resolve(downstreamNames);
+      })
+      .on('error', reject);
+  });
+}

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -4953,7 +4953,7 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.1, minipass@^2.2.4, minipass@^2.3.4:
+minipass@^2.2.1, minipass@^2.2.4, minipass@^2.3.4, minipass@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
   integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
@@ -4961,7 +4961,7 @@ minipass@^2.2.1, minipass@^2.2.4, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minizlib@^1.1.0, minizlib@^1.1.1:
+minizlib@^1.1.0, minizlib@^1.1.1, minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
@@ -7451,6 +7451,19 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+tar@^4.4.10:
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
+  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.5"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
@@ -8259,7 +8272,7 @@ yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yallist@^3.0.0, yallist@^3.0.2:
+yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==

--- a/migrations/tables/app_downstream.yaml
+++ b/migrations/tables/app_downstream.yaml
@@ -1,0 +1,26 @@
+apiVersion: schemas.schemahero.io/v1alpha2
+kind: Table
+metadata:
+  name: app-downstream
+spec:
+  database: kotsadm-postgres
+  name: app_downstream
+  requires: []
+  schema:
+    postgres:
+      primaryKey:
+        - app_id
+        - cluster_id
+      columns:
+      - name: app_id
+        type: text
+        constraints:
+          notNull: true
+      - name: cluster_id
+        type: text
+        constraints:
+          notNull: true
+      - name: downstream_name
+        type: text
+        constraints:
+          notNull: true

--- a/migrations/tables/kustomization.yaml
+++ b/migrations/tables/kustomization.yaml
@@ -46,3 +46,4 @@ resources:
 - ./app.yaml
 - ./app_version.yaml
 - ./user_app.yaml
+- ./app_downstream.yaml


### PR DESCRIPTION
This PR modifies the behavior of the `kots upload` command. It will now look for a overlays/downstreams/:1/kustomization.yaml in the upload archive, and if there's a cluster (all-users) that matches this :1 param, it will add this as a downstream in the postgres database.