### PR TITLE
Poll on downstream version history page for pending preflights

### DIFF
--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -266,6 +266,7 @@ class AppDetailPage extends Component {
     );
 
     const app = getKotsAppQuery?.getKotsApp;
+    const refreshAppData = getKotsAppQuery.refetch;
     const loading = getKotsAppQuery?.loading || !rootDidInitialAppFetch;
 
     if (!rootDidInitialAppFetch) {
@@ -377,6 +378,7 @@ class AppDetailPage extends Component {
                       <DownstreamWatchVersionHistory
                         watch={app}
                         makeCurrentVersion={this.makeCurrentRelease}
+                        refreshAppData={refreshAppData}
                       />
                     } />
                     <Route exact path="/app/:slug/downstreams/:downstreamSlug/version-history/preflight/:sequence" render={() => {

--- a/web/src/components/watches/DownstreamWatchVersionHistory.jsx
+++ b/web/src/components/watches/DownstreamWatchVersionHistory.jsx
@@ -9,7 +9,7 @@ import { getDownstreamHistory } from "../../queries/WatchQueries";
 import { getKotsDownstreamHistory } from "../../queries/AppsQueries";
 
 import "@src/scss/components/watches/WatchVersionHistory.scss";
-import { isKotsApplication } from "../../utilities/utilities";
+import { isKotsApplication, hasPendingPreflight } from "../../utilities/utilities";
 
 class DownstreamWatchVersionHistory extends Component {
 
@@ -39,6 +39,13 @@ class DownstreamWatchVersionHistory extends Component {
         <Loader size="60" />
       </div>
     );
+
+    if (isKots && hasPendingPreflight(versionHistory)) {
+      data?.startPolling(2000);
+    } else {
+      this.props?.refreshAppData();
+      data?.stopPolling();
+    }
 
     return (
       <div className="flex-column flex1 u-position--relative u-padding--20 u-overflow--auto">

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -262,6 +262,21 @@ export function isKotsApplication(watch) {
   return Boolean(watch.name);
 }
 
+/**
+ * Returns true if any item in version history is awaiting preflight results
+ * from kotsadm operator.
+ * @param {Array} versionHistory - Downstream version history for a kots app
+ * @return {Boolean}
+ */
+export function hasPendingPreflight(versionHistory) {
+  for(const version of versionHistory) {
+    if (version.status === "pending_preflight") {
+      return true;
+    }
+  }
+  return false;
+}
+
 export const Utilities = {
   getToken() {
     if (this.localStorageEnabled()) {


### PR DESCRIPTION
Something to note:

I had to add in a `refreshAppData` prop to `<DownstreamWatchVersionHistory>` because the active release is a prop that's passed in, and won't react to any data changes in the current GraphQL query. Instead of duplicating data, I figured it would be better to grab it from the source of truth instead.