### PR TITLE
Disable kotsadm production gitops-deploys to freeze our ship-cluster …

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -87,7 +87,7 @@ publish-release: GITOPS_OWNER = replicatedcom
 publish-release: GITOPS_REPO = gitops-deploy
 publish-release: GITOPS_BRANCH = release
 publish-release: GITOPS_FILENAME = kotsadm-api
-publish-release: build_and_publish
+#publish-release: build_and_publish
 
 .PHONY: publish-alpha
 publish-alpha: IMAGE_TAG = alpha

--- a/migrations/Makefile
+++ b/migrations/Makefile
@@ -19,7 +19,7 @@ publish-release: OVERLAY = production
 publish-release: GITOPS_OWNER = replicatedcom
 publish-release: GITOPS_REPO = gitops-deploy
 publish-release: GITOPS_BRANCH = release
-publish-release: gitops
+#publish-release: gitops
 
 .PHONY: publish-alpha
 publish-alpha: OVERLAY = staging

--- a/web/Makefile
+++ b/web/Makefile
@@ -102,7 +102,7 @@ release-replicated-production: OVERLAY = production
 release-replicated-production: GITOPS_OWNER = replicatedcom
 release-replicated-production: GITOPS_REPO = gitops-deploy
 release-replicated-production: GITOPS_BRANCH = release
-release-replicated-production: gitops
+#release-replicated-production: gitops
 
 gitops:
 	cd kustomize/overlays/$(OVERLAY); sed -i -- 's/GIT_SHA_PLACEHOLDER/'$${BUILDKITE_COMMIT:0:7}'/g' *.yaml

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -91,7 +91,7 @@ publish-release: GITOPS_OWNER = replicatedcom
 publish-release: GITOPS_REPO = gitops-deploy
 publish-release: GITOPS_BRANCH = release
 publish-release: GITOPS_FILENAME = kotsadm-worker
-publish-release: build_and_publish
+#publish-release: build_and_publish
 
 .PHONY: publish-alpha
 publish-alpha: IMAGE_TAG = alpha


### PR DESCRIPTION
This change is intended to freeze our prod www.replicated.com/ship code at the current stable kots v0.9.9, but keep publishing labeled images to be available to kots & kurl.