### PR TITLE
move kotsadm-web service to nodeport

### DIFF
--- a/web/kustomize/overlays/staging/kustomization.yaml
+++ b/web/kustomize/overlays/staging/kustomization.yaml
@@ -2,7 +2,7 @@ bases:
   - ../../base
 
 resources:
-  - ./clusterip.yaml
+  - ./nodeport.yaml
 
 patchesStrategicMerge:
   - ./deployment.yaml

--- a/web/kustomize/overlays/staging/nodeport.yaml
+++ b/web/kustomize/overlays/staging/nodeport.yaml
@@ -5,9 +5,10 @@ metadata:
   labels:
     app: kotsadm-web
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
   - name: http
+    nodePort: 30065
     port: 3000
     targetPort: http
   selector:


### PR DESCRIPTION
Expose kotsadm-web as a NodePort service, so that we can proxy it via CloudFlare, rather than depending on a 'www' EKS service to do the proxying.

Doing Staging independently from Prod, so that it won't block the runway while it's being tested.