### PR TITLE
use existing user 'nginx' within web docker container

### DIFF
--- a/web/deploy/Dockerfile
+++ b/web/deploy/Dockerfile
@@ -1,15 +1,11 @@
-FROM nginx:1.11.8
+FROM nginx:1.17.5
 ARG version
 ARG nginxconf=deploy/nginx.conf
 
-COPY dist /usr/share/nginx/html
-COPY ${nginxconf} /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:nginx dist /usr/share/nginx/html
+COPY --chown=nginx:nginx ${nginxconf} /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:nginx deploy/root-nginx.conf /etc/nginx/nginx.conf
 
-RUN useradd -c 'kotsadm-web user' -m -d /home/kotsadm-web -s /bin/bash -u 1001 kotsadm-web
-RUN chown -R kotsadm-web.kotsadm-web /usr/share/nginx/html
-RUN chown -R kotsadm-web.kotsadm-web /etc/nginx/conf.d/default.conf
-USER kotsadm-web
-ENV HOME /home/kotsadm-web
+USER nginx
 
 STOPSIGNAL SIGTERM
-

--- a/web/deploy/root-nginx.conf
+++ b/web/deploy/root-nginx.conf
@@ -1,0 +1,38 @@
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+
+


### PR DESCRIPTION
The additional nginx configuration replaces the default config with a variant that 

1. doesn't include a 'user' directive
2. uses paths in `/tmp` instead of `/var/cache/nginx`
3. uses `/tmp/nginx.pid` instead of `/var/run/nginx.pid`

as described on the docker image page [here](https://hub.docker.com/_/nginx).

The nginx version is also upgraded to 1.17.5, as 1.17 was the first to use consistent user/group IDs.