### PR TITLE
bump patch versions for embedded kubectl binaries

### DIFF
--- a/operator/Dockerfile.skaffold
+++ b/operator/Dockerfile.skaffold
@@ -1,18 +1,18 @@
 FROM golang:1.12 as deps
 
 # Install Kubectl 1.14
-ENV KUBECTL_1_14_VERSION=v1.14.7
+ENV KUBECTL_1_14_VERSION=v1.14.9
 ENV KUBECTL_1_14_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_1_14_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_14_SHA256SUM=153fdf0ab8892b4c5e736b3f7c30a89cd4f1753c4d035ec8d771904b17ad181d
+ENV KUBECTL_1_14_SHA256SUM=d2a31e87c5f6deced4ba8899f9c465e54822f0cd146f32ea83cb1daafa5d9c4f
 RUN curl -fsSLO "${KUBECTL_1_14_URL}" \
 	&& echo "${KUBECTL_1_14_SHA256SUM}  kubectl" | sha256sum -c - \
 	&& chmod +x kubectl \
 	&& mv kubectl "/usr/local/bin/kubectl-${KUBECTL_1_14_VERSION}"
 
 # Install Kubectl 1.16
-ENV KUBECTL_1_16_VERSION=v1.16.1
+ENV KUBECTL_1_16_VERSION=v1.16.3
 ENV KUBECTL_1_16_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_1_16_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_16_SHA256SUM=69cfb3eeaa0b77cc4923428855acdfc9ca9786544eeaff9c21913be830869d29
+ENV KUBECTL_1_16_SHA256SUM=cded1b46405741575f31024b757fd967645e815bb0ab1c5f5fcd029f25cc0f2d
 RUN curl -fsSLO "${KUBECTL_1_16_URL}" \
 	&& echo "${KUBECTL_1_16_SHA256SUM}  kubectl" | sha256sum -c - \
 	&& chmod +x kubectl \

--- a/operator/deploy/Dockerfile
+++ b/operator/deploy/Dockerfile
@@ -5,18 +5,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Kubectl 1.14
-ENV KUBECTL_1_14_VERSION=v1.14.7
+ENV KUBECTL_1_14_VERSION=v1.14.9
 ENV KUBECTL_1_14_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_1_14_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_14_SHA256SUM=153fdf0ab8892b4c5e736b3f7c30a89cd4f1753c4d035ec8d771904b17ad181d
+ENV KUBECTL_1_14_SHA256SUM=d2a31e87c5f6deced4ba8899f9c465e54822f0cd146f32ea83cb1daafa5d9c4f
 RUN curl -fsSLO "${KUBECTL_1_14_URL}" \
 	&& echo "${KUBECTL_1_14_SHA256SUM}  kubectl" | sha256sum -c - \
 	&& chmod +x kubectl \
 	&& mv kubectl "/usr/local/bin/kubectl-${KUBECTL_1_14_VERSION}"
 
 # Install Kubectl 1.16
-ENV KUBECTL_1_16_VERSION=v1.16.1
+ENV KUBECTL_1_16_VERSION=v1.16.3
 ENV KUBECTL_1_16_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_1_16_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_16_SHA256SUM=69cfb3eeaa0b77cc4923428855acdfc9ca9786544eeaff9c21913be830869d29
+ENV KUBECTL_1_16_SHA256SUM=cded1b46405741575f31024b757fd967645e815bb0ab1c5f5fcd029f25cc0f2d
 RUN curl -fsSLO "${KUBECTL_1_16_URL}" \
 	&& echo "${KUBECTL_1_16_SHA256SUM}  kubectl" | sha256sum -c - \
 	&& chmod +x kubectl \

--- a/operator/pkg/util/kubectl_version.go
+++ b/operator/pkg/util/kubectl_version.go
@@ -10,8 +10,8 @@ import (
 )
 
 var knownKubectlVersions = []semver.Version{
-	semver.MustParse("1.16.1"),
-	semver.MustParse("1.14.7"),
+	semver.MustParse("1.16.3"),
+	semver.MustParse("1.14.9"),
 }
 
 // finds a known version that matches the provided range

--- a/operator/pkg/util/kubectl_version_test.go
+++ b/operator/pkg/util/kubectl_version_test.go
@@ -21,29 +21,29 @@ func Test_matchKnownVersion(t *testing.T) {
 			want:       "",
 		},
 		{
-			name:       "1.16.1",
-			userString: "1.16.1",
-			want:       "v1.16.1",
+			name:       "1.16.3",
+			userString: "1.16.3",
+			want:       "v1.16.3",
 		},
 		{
 			name:       "1.14.x",
 			userString: "1.14.x",
-			want:       "v1.14.7",
+			want:       "v1.14.9",
 		},
 		{
 			name:       "<1.15.0",
 			userString: "<1.15.0",
-			want:       "v1.14.7",
+			want:       "v1.14.9",
 		},
 		{
 			name:       ">1.15.0 <1.17.0",
 			userString: ">1.15.0 <1.17.0",
-			want:       "v1.16.1",
+			want:       "v1.16.3",
 		},
 		{
 			name:       "<1.17.0",
 			userString: "<1.17.0",
-			want:       "v1.16.1",
+			want:       "v1.16.3",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
1.14.7 to 1.14.9, 1.16.1 to 1.16.3

best to do this _before_ writing down the supported versions list in our docs