### PR TITLE
bump ship init component to 1.6.13

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -110,7 +110,7 @@
     "@bugsnag/plugin-react": "^6.2.0",
     "@grafana/ui": "^6.4.3",
     "@maji/react-prism": "^1.0.1",
-    "@replicatedhq/ship-init": "1.6.12",
+    "@replicatedhq/ship-init": "1.6.13",
     "apollo-cache-inmemory": "^1.5.1",
     "apollo-client": "^2.5.1",
     "apollo-link": "^1.2.11",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1100,10 +1100,10 @@
     pkginfo "^0.4.1"
     popsicle "^9.2.0"
 
-"@replicatedhq/ship-init@1.6.12":
-  version "1.6.12"
-  resolved "https://registry.yarnpkg.com/@replicatedhq/ship-init/-/ship-init-1.6.12.tgz#d00a1aafb074a2259a92cc6af60b54931c20d192"
-  integrity sha512-JkIpknekd3nAUD/POLt1ImFeZ/0cTR81uHWe46WFaqnDeTkgeQnQjBWXTJyB73KtGgSIPUfpS0YeE/bhwBrJ6A==
+"@replicatedhq/ship-init@1.6.13":
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/@replicatedhq/ship-init/-/ship-init-1.6.13.tgz#23a4d26e4948a1942329129f46ac8e66f5ff0ba0"
+  integrity sha512-MHZNTN8zgAzwHS258CXzR0OasjCjvleI4kJuMp3ztCbB4QmIbWCnepBfxbgvyvXsTtYEbexmxLNk5qASwm6i9A==
   dependencies:
     brace "^0.11.1"
     classnames "^2.2.6"


### PR DESCRIPTION
Fixes error caused by using string as default value of a checkbox.