### PR TITLE
Remove schemahero deployments to staging

### DIFF
--- a/migrations/.buildkite/pipeline.yml
+++ b/migrations/.buildkite/pipeline.yml
@@ -5,10 +5,3 @@ steps:
 
   - commands:
       - if [ ! -z "$GIT_TAG" ]; then make -C migrations schema-release; fi
-
-  - commands:
-      - make -C migrations publish-alpha
-    branches: "master"
-
-  - commands:
-      - if [ ! -z "$GIT_TAG" ]; then make -C migrations publish-release; fi

--- a/migrations/Makefile
+++ b/migrations/Makefile
@@ -13,32 +13,3 @@ build_schema:
 	docker pull schemahero/schemahero:alpha
 	docker build -f deploy/Dockerfile -t ${IMAGE} .
 	docker push ${IMAGE}
-
-.PHONY: publish-release
-publish-release: OVERLAY = production
-publish-release: GITOPS_OWNER = replicatedcom
-publish-release: GITOPS_REPO = gitops-deploy
-publish-release: GITOPS_BRANCH = release
-#publish-release: gitops
-
-.PHONY: publish-alpha
-publish-alpha: OVERLAY = staging
-publish-alpha: GITOPS_OWNER = replicatedcom
-publish-alpha: GITOPS_REPO = gitops-deploy
-publish-alpha: GITOPS_BRANCH = master
-publish-alpha: gitops
-
-gitops:
-	cd kustomize/overlays/$(OVERLAY); sed -i -- 's/GIT_SHA_PLACEHOLDER/'$${BUILDKITE_COMMIT:0:7}'/g' *.yaml
-
-	rm -rf deploy/$(OVERLAY)/work
-	mkdir -p deploy/$(OVERLAY)/work; cd deploy/$(OVERLAY)/work; git clone --single-branch -b $(GITOPS_BRANCH) git@github.com:$(GITOPS_OWNER)/$(GITOPS_REPO)
-	mkdir -p deploy/$(OVERLAY)/work/$(GITOPS_REPO)/${PROJECT_NAME}
-
-	kustomize build kustomize/overlays/$(OVERLAY) > deploy/$(OVERLAY)/work/$(GITOPS_REPO)/${PROJECT_NAME}/${PROJECT_NAME}.yaml
-
-	cd deploy/$(OVERLAY)/work/$(GITOPS_REPO)/${PROJECT_NAME}; \
-	  git add . ;\
-	  git commit --allow-empty -m "$${BUILDKITE_BUILD_URL}"; \
-          git push origin $(GITOPS_BRANCH)
-


### PR DESCRIPTION
Missed in last week's cleanup & overhaul.  It's no longer necessary to deploy schemahero changes to  gitops/staging/prod.