### PR TITLE
use non-root minio user, and build the image in a different buildkite context

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,9 +80,15 @@ steps:
     commands:
       - make -C minio publish-latest
     branches: "master"
+    agents:
+      root-docker: "true"
+      queue: root-docker
 
   - label: "release-minio"
     env:
       GIT_TAG: "${BUILDKITE_TAG}"
     commands:
       - if [ ! -z "$GIT_TAG" ]; then make -C minio publish-release; fi
+    agents:
+      root-docker: "true"
+      queue: root-docker

--- a/kustomize/overlays/dev/minio/statefulset.yaml
+++ b/kustomize/overlays/dev/minio/statefulset.yaml
@@ -17,6 +17,9 @@ spec:
         release: minio
       name: minio
     spec:
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - args:
           - server
@@ -34,8 +37,8 @@ spec:
               name: minio
         - name: MINIO_BROWSER
           value: "on"
-        image: minio/minio:RELEASE.2019-10-12T01-39-57Z
-        imagePullPolicy: IfNotPresent
+        image: kotsadm/minio:alpha
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -66,6 +69,23 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: miniodata  # this is where the data is stored
+      initContainers:
+      - command:
+        - chown
+        args:
+        - "-R"
+        - "1001:1001"
+        - /data
+        image: kotsadm/minio:alpha
+        imagePullPolicy: Always
+        name: minio-chown
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /data
+          name: miniodata  # this is where the data is stored
       volumes:
       - name: miniodata
         persistentVolumeClaim:

--- a/minio/Dockerfile
+++ b/minio/Dockerfile
@@ -1,6 +1,10 @@
 FROM minio/minio:RELEASE.2019-10-12T01-39-57Z
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates libcap && rm -rf /var/cache/apk/*
+
+# /bin/busybox is the backend to /bin/chown, and so this allows any user to change any file ownership
+# this in turn allows the init container to take ownership of the data directory, so that minio can run
+RUN setcap cap_chown=+ep /bin/busybox
 
 RUN adduser -h /home/minio -s /bin/sh -u 1001 -D minio
 USER minio


### PR DESCRIPTION
minio will run as uid 1001, and has an initcontainer to chown the files previously created by minio running as root

setcap requires a docker install not set to run as a user other than root, so the relevant build agents are restricted to that set of builders