### PR TITLE
API for check for updates

### DIFF
--- a/api/src/kots_app/resolvers/kots_app_mutations.ts
+++ b/api/src/kots_app/resolvers/kots_app_mutations.ts
@@ -56,7 +56,7 @@ export function KotsMutations(stores: Stores) {
         });
       }, 1000);
 
-      var updatesAvailable: Update[];
+      let updatesAvailable: Update[];
       try {
         await stores.kotsAppStore.setUpdateDownloadStatus("Checking for updates...", "running");
 


### PR DESCRIPTION
This adds a new REST method to the cluster-ip api to support replicatedhq/kots#204