### PR TITLE
Allow binary files in a kot release

### DIFF
--- a/api/Dockerfile.skaffold
+++ b/api/Dockerfile.skaffold
@@ -16,7 +16,7 @@ RUN curl -L "https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0
   chmod a+x /tmp/kustomize && \
   mv /tmp/kustomize /usr/local/bin
 
-RUN curl -L "https://github.com/replicatedhq/kots/releases/download/v1.8.0-beta.8/kots.so_linux_amd64.tar.gz" > /tmp/kots.tar.gz && \
+RUN curl -L "https://github.com/replicatedhq/kots/releases/download/v1.8.0-beta.9/kots.so_linux_amd64.tar.gz" > /tmp/kots.tar.gz && \
 cd /tmp && tar xzvf kots.tar.gz && \
 mv /tmp/kots.so /lib/kots.so
 

--- a/api/deploy/Dockerfile
+++ b/api/deploy/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -L "https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0
   mv /tmp/kustomize /usr/local/bin
 
 # Install kots.so
-RUN curl -L "https://github.com/replicatedhq/kots/releases/download/v1.8.0-beta.8/kots.so_linux_amd64.tar.gz" > /tmp/kots.tar.gz && \
+RUN curl -L "https://github.com/replicatedhq/kots/releases/download/v1.8.0-beta.9/kots.so_linux_amd64.tar.gz" > /tmp/kots.tar.gz && \
   cd /tmp && tar xzvf kots.tar.gz && \
   mv /tmp/kots.so /lib/kots.so && \
   rm -rf /tmp/*

--- a/api/src/kots_app/kots_ffi.ts
+++ b/api/src/kots_app/kots_ffi.ts
@@ -838,7 +838,7 @@ export async function kotsRewriteVersion(archive: string, downstreams: string[],
     updatedConfigValuesParam["p"] = updatedConfigValues;
     updatedConfigValuesParam["n"] = updatedConfigValues.length;
 
-    kots().RewriteVersion(socketParam, inputPathParam, outputFileParam, downstreamsParam, k8sNamespaceParam, registryJsonParam, copyImages, updatedConfigValues);
+    kots().RewriteVersion(socketParam, inputPathParam, outputFileParam, downstreamsParam, k8sNamespaceParam, registryJsonParam, copyImages, updatedConfigValuesParam);
 
     let errrorMessage = "";
 

--- a/api/src/kots_app/kots_ffi.ts
+++ b/api/src/kots_app/kots_ffi.ts
@@ -47,7 +47,7 @@ function kots() {
     UpdateDownload: ["void", [GoString, GoString, GoString, GoString, GoString]],
     ReadMetadata: ["void", [GoString, GoString]],
     RemoveMetadata: ["void", [GoString, GoString]],
-    RewriteVersion: ["void", [GoString, GoString, GoString, GoString, GoString, GoString, GoBool]],
+    RewriteVersion: ["void", [GoString, GoString, GoString, GoString, GoString, GoString, GoBool, GoString]],
     TemplateConfig: [GoString, [GoString, GoString]],
     EncryptString: [GoString, [GoString, GoString]],
     DecryptString: [GoString, [GoString, GoString]],
@@ -800,7 +800,7 @@ export async function getLatestLicense(licenseData: string): Promise<string> {
   }
 }
 
-export async function kotsRewriteVersion(archive: string, downstreams: string[], registryInfo: KotsAppRegistryDetails, copyImages: boolean, outputFile: string, stores: Stores): Promise<string> {
+export async function kotsRewriteVersion(archive: string, downstreams: string[], registryInfo: KotsAppRegistryDetails, copyImages: boolean, outputFile: string, stores: Stores, updatedConfigValues: string): Promise<string> {
   const tmpDir = tmp.dirSync();
   try {
     const k8sNamespace = getK8sNamespace();
@@ -834,7 +834,11 @@ export async function kotsRewriteVersion(archive: string, downstreams: string[],
     registryJsonParam["p"] = registryJson;
     registryJsonParam["n"] = registryJson.length;
 
-    kots().RewriteVersion(socketParam, inputPathParam, outputFileParam, downstreamsParam, k8sNamespaceParam, registryJsonParam, copyImages);
+    const updatedConfigValuesParam = new GoString();
+    updatedConfigValuesParam["p"] = updatedConfigValues;
+    updatedConfigValuesParam["n"] = updatedConfigValues.length;
+
+    kots().RewriteVersion(socketParam, inputPathParam, outputFileParam, downstreamsParam, k8sNamespaceParam, registryJsonParam, copyImages, updatedConfigValues);
 
     let errrorMessage = "";
 

--- a/api/src/kots_app/resolvers/kots_app_mutations.ts
+++ b/api/src/kots_app/resolvers/kots_app_mutations.ts
@@ -241,7 +241,7 @@ export function KotsMutations(stores: Stores) {
                 lastSyncedAt: "",
                 namespace: namespace,
               }
-              await kotsRewriteVersion(inputArchive, downstreams, registryInfo, true, outputArchive, stores);
+              await kotsRewriteVersion(inputArchive, downstreams, registryInfo, true, outputArchive, stores, "");
 
               await stores.kotsAppStore.setImageRewriteStatus("Generating new version", "running");
 


### PR DESCRIPTION
We shouldn't assume that all files are strings.