### PR TITLE
Handle deploying CRDs and CRs in an app

### DIFF
--- a/operator/pkg/client/client.go
+++ b/operator/pkg/client/client.go
@@ -420,7 +420,7 @@ func (c *Client) diffAndRemovePreviousManifests(applicationManifests Application
 		if _, ok := decodedCurrentMap[k]; !ok {
 			gv, k, n, err := ParseSimpleGVK([]byte(oldContents))
 			if err != nil {
-				log.Println("deleting unidentified manifest")
+				log.Printf("deleting unidentified manifest. unable to parse error: %s\n", err.Error())
 			} else {
 				log.Printf("deleting manifest(s): %s/%s/%s\n", gv, k, n)
 			}

--- a/operator/pkg/client/client.go
+++ b/operator/pkg/client/client.go
@@ -432,14 +432,6 @@ func (c *Client) diffAndRemovePreviousManifests(applicationManifests Application
 }
 
 func (c *Client) ensureResourcesPresent(applicationManifests ApplicationManifests) error {
-	decoded, err := base64.StdEncoding.DecodeString(applicationManifests.Manifests)
-	if err != nil {
-		return errors.Wrap(err, "failed to decode manifests")
-	}
-
-	// TODO sort, order matters
-	// TODO should we split multi-doc to retry on failed?
-
 	kubectl, err := util.FindKubectlVersion(applicationManifests.KubectlVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to find kubectl")
@@ -471,33 +463,62 @@ func (c *Client) ensureResourcesPresent(applicationManifests ApplicationManifest
 		targetNamespace = applicationManifests.Namespace
 	}
 
-	log.Println("dry run applying manifests(s)")
-	drrunStdout, dryrunStderr, dryRunErr := kubernetesApplier.Apply(targetNamespace, decoded, true)
-	if dryRunErr != nil {
-		log.Printf("stdout (dryrun) = %s", drrunStdout)
-		log.Printf("stderr (dryrun) = %s", dryrunStderr)
-		log.Printf("error: %s", dryRunErr.Error())
+	decoded, err := base64.StdEncoding.DecodeString(applicationManifests.Manifests)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode manifests")
 	}
 
-	var applyStdout []byte
-	var applyStderr []byte
-	var applyErr error
-	if dryRunErr == nil {
-		log.Println("applying manifest(s)")
-		stdout, stderr, err := kubernetesApplier.Apply(targetNamespace, decoded, false)
-		if err != nil {
-			log.Printf("stdout (apply) = %s", stdout)
-			log.Printf("stderr (apply) = %s", stderr)
-			log.Printf("error: %s", err.Error())
+	customResourceDefinitions, otherDocs, err := splitMutlidocYAMLIntoCRDsAndOthers(decoded)
+	if err != nil {
+		return errors.Wrap(err, "failed to split decoded into crds and other")
+	}
+
+	// We don't dry run if there's a crd becasue there's a likely chance that the
+	// other docs has a custom resource using it
+	shouldDryRun := customResourceDefinitions != nil
+	if shouldDryRun {
+		log.Println("dry run applying manifests(s)")
+		dryrunStdout, dryrunStderr, dryRunErr := kubernetesApplier.Apply(targetNamespace, decoded, true)
+		if dryRunErr != nil {
+			log.Printf("stdout (dryrun) = %s", dryrunStdout)
+			log.Printf("stderr (dryrun) = %s", dryrunStderr)
+			log.Printf("error: %s", dryRunErr.Error())
 		}
 
-		applyStdout = stdout
-		applyStderr = stderr
-		applyErr = err
+		if dryRunErr != nil {
+			if err := c.sendResult(applicationManifests, true, dryrunStdout, dryrunStderr, []byte{}, []byte{}); err != nil {
+				return errors.Wrap(err, "failed to report dry run status")
+			}
+
+			return nil // don't return an error because execution is proper, the api now has the error
+		}
 	}
 
-	hasErr := applyErr != nil || dryRunErr != nil
-	if err := c.sendResult(applicationManifests, hasErr, drrunStdout, dryrunStderr, applyStdout, applyStderr); err != nil {
+	if len(customResourceDefinitions) > 0 {
+		log.Println("applying custom resource definition(s)")
+		applyStdout, applyStderr, applyErr := kubernetesApplier.Apply(targetNamespace, customResourceDefinitions, false)
+		if applyErr != nil {
+			log.Printf("stdout (apply CRDS) = %s", applyStdout)
+			log.Printf("stderr (apply CRDS) = %s", applyStderr)
+			log.Printf("error (CRDS): %s", applyErr.Error())
+
+			if err := c.sendResult(applicationManifests, applyErr != nil, []byte{}, []byte{}, applyStdout, applyStderr); err != nil {
+				return errors.Wrap(err, "failed to report crd status")
+			}
+
+			return nil
+		}
+	}
+
+	log.Println("applying manifest(s)")
+	applyStdout, applyStderr, applyErr := kubernetesApplier.Apply(targetNamespace, otherDocs, false)
+	if err != nil {
+		log.Printf("stdout (apply) = %s", applyStdout)
+		log.Printf("stderr (apply) = %s", applyStderr)
+		log.Printf("error: %s", applyErr.Error())
+	}
+
+	if err := c.sendResult(applicationManifests, applyErr != nil, []byte{}, []byte{}, applyStdout, applyStderr); err != nil {
 		return errors.Wrap(err, "failed to report status")
 	}
 

--- a/operator/pkg/client/client.go
+++ b/operator/pkg/client/client.go
@@ -508,6 +508,9 @@ func (c *Client) ensureResourcesPresent(applicationManifests ApplicationManifest
 
 			return nil
 		}
+
+		// Give the API server a minute (well, 5 seconds) to cache the CRDs
+		time.Sleep(time.Second * 5)
 	}
 
 	log.Println("applying manifest(s)")

--- a/operator/pkg/client/deploy.go
+++ b/operator/pkg/client/deploy.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"encoding/base64"
+	"log"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func (c *Client) ensureResourcesPresent(applicationManifests ApplicationManifests) error {
+	targetNamespace := c.TargetNamespace
+	if applicationManifests.Namespace != "." {
+		targetNamespace = applicationManifests.Namespace
+	}
+
+	kubernetesApplier, err := c.getApplier(applicationManifests.KubectlVersion)
+	if err != nil {
+		return errors.Wrap(err, "failed to get applier")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(applicationManifests.Manifests)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode manifests")
+	}
+
+	customResourceDefinitions, otherDocs, err := splitMutlidocYAMLIntoCRDsAndOthers(decoded)
+	if err != nil {
+		return errors.Wrap(err, "failed to split decoded into crds and other")
+	}
+
+	// We don't dry run if there's a crd becasue there's a likely chance that the
+	// other docs has a custom resource using it
+	shouldDryRun := customResourceDefinitions == nil
+	if shouldDryRun {
+		byNamespace, err := docsByNamespace(decoded, targetNamespace)
+		if err != nil {
+			return errors.Wrap(err, "failed to get docs by requested namespace")
+		}
+
+		for requestedNamespace, docs := range byNamespace {
+			log.Printf("dry run applying manifests(s) in requested namespace: %s\n", requestedNamespace)
+			dryrunStdout, dryrunStderr, dryRunErr := kubernetesApplier.Apply(requestedNamespace, docs, true)
+			if dryRunErr != nil {
+				log.Printf("stdout (dryrun) = %s", dryrunStdout)
+				log.Printf("stderr (dryrun) = %s", dryrunStderr)
+				log.Printf("error: %s", dryRunErr.Error())
+			}
+
+			if dryRunErr != nil {
+				if err := c.sendResult(applicationManifests, true, dryrunStdout, dryrunStderr, []byte{}, []byte{}); err != nil {
+					return errors.Wrap(err, "failed to report dry run status")
+				}
+
+				return nil // don't return an error because execution is proper, the api now has the error
+			}
+		}
+
+	}
+
+	if len(customResourceDefinitions) > 0 {
+		log.Println("applying custom resource definition(s)")
+
+		// CRDs don't have namespaces, so we can skip splitting
+
+		applyStdout, applyStderr, applyErr := kubernetesApplier.Apply("", customResourceDefinitions, false)
+		if applyErr != nil {
+			log.Printf("stdout (apply CRDS) = %s", applyStdout)
+			log.Printf("stderr (apply CRDS) = %s", applyStderr)
+			log.Printf("error (CRDS): %s", applyErr.Error())
+
+			if err := c.sendResult(applicationManifests, applyErr != nil, []byte{}, []byte{}, applyStdout, applyStderr); err != nil {
+				return errors.Wrap(err, "failed to report crd status")
+			}
+
+			return nil
+		}
+
+		// Give the API server a minute (well, 5 seconds) to cache the CRDs
+		time.Sleep(time.Second * 5)
+	}
+
+	byNamespace, err := docsByNamespace(otherDocs, targetNamespace)
+	if err != nil {
+		return errors.Wrap(err, "failed to get docs by requested namespace")
+	}
+
+	for requestedNamespace, docs := range byNamespace {
+		log.Printf("applying manifest(s) in namespace %s\n", requestedNamespace)
+		applyStdout, applyStderr, applyErr := kubernetesApplier.Apply(requestedNamespace, docs, false)
+		if err != nil {
+			log.Printf("stdout (apply) = %s", applyStdout)
+			log.Printf("stderr (apply) = %s", applyStderr)
+			log.Printf("error: %s", applyErr.Error())
+		}
+
+		if err := c.sendResult(applicationManifests, applyErr != nil, []byte{}, []byte{}, applyStdout, applyStderr); err != nil {
+			return errors.Wrap(err, "failed to report status")
+		}
+	}
+
+	return nil
+}

--- a/operator/pkg/client/doc.go
+++ b/operator/pkg/client/doc.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"strings"
+)
+
+func splitMutlidocYAMLIntoCRDsAndOthers(multidoc []byte) ([]byte, []byte, error) {
+	crds := []string{}
+	other := []string{}
+
+	docs := strings.Split(string(multidoc), "\n---\n")
+	for _, doc := range docs {
+		if IsCRD([]byte(doc)) {
+			crds = append(crds, doc)
+		} else {
+			other = append(other, doc)
+		}
+	}
+
+	// if there were no crds, don't return the touched docs, keep the original
+	if len(crds) == 0 {
+		return nil, multidoc, nil
+	}
+
+	return []byte(strings.Join(crds, "\n---\n")), []byte(strings.Join(other, "\n---\n")), nil
+}

--- a/operator/pkg/client/gvkn.go
+++ b/operator/pkg/client/gvkn.go
@@ -14,7 +14,8 @@ type OverlySimpleGVKWithName struct {
 }
 
 type OverlySimpleMetadata struct {
-	Name string `yaml:"name"`
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
 }
 
 func GetGVKWithName(content []byte) string {
@@ -37,4 +38,14 @@ func IsCRD(content []byte) bool {
 	}
 
 	return o.APIVersion == "apiextensions.k8s.io/v1beta1" && o.Kind == "CustomResourceDefinition"
+}
+
+func ParseSimpleGVK(content []byte) (string, string, string, error) {
+	o := OverlySimpleGVKWithName{}
+
+	if err := yaml.Unmarshal(content, &o); err != nil {
+		return "", "", "", nil
+	}
+
+	return o.APIVersion, o.Kind, o.Metadata.Name, nil
 }

--- a/operator/pkg/client/gvkn.go
+++ b/operator/pkg/client/gvkn.go
@@ -28,3 +28,13 @@ func GetGVKWithName(content []byte) string {
 	h.Write([]byte(fmt.Sprintf("%s-%s-%s", o.APIVersion, o.Kind, o.Metadata.Name)))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
+
+func IsCRD(content []byte) bool {
+	o := OverlySimpleGVKWithName{}
+
+	if err := yaml.Unmarshal(content, &o); err != nil {
+		return false
+	}
+
+	return o.APIVersion == "apiextensions.k8s.io/v1beta1" && o.Kind == "CustomResourceDefinition"
+}

--- a/operator/pkg/client/hooks.go
+++ b/operator/pkg/client/hooks.go
@@ -46,7 +46,7 @@ func (c *Client) runHooksInformer() error {
 					// if the job doesn't contain our annotation, ignore it
 					hookValue, ok := job.Annotations["kots.io/hook-delete-policy"]
 					if !ok {
-						fmt.Println("no annotation found, ignoring")
+						fmt.Println("no annotation found on job, not going to handle any cleanup")
 						return
 					}
 


### PR DESCRIPTION
This changes the behavior of how KOTS operator deploys in order to make it possible to deploy an application that contains both CRDs and custom resources that reference these CRDs.

The old behavior was to `--dry-run` apply and fail the deployment if that fails. This won't ever work for a custom resource that references a CRD in the deployment because the API server never adds the CRD to the cache, even with server side dry run.

Now, if there are no CRDs in the resources, the same (old) logic is applied. No changes.

If the application does contain a CRD, we will now skip the dry-run phase and proceed to a new, 2 phase deploy. First we will apply everything that has a `kind: CustomResourceDefinition`. Then, after that completes successfully, we will wait 5 seconds and then apply the rest of the documents. Errors will be reported to the kots API server.