### PR TITLE
Use relative url for api

### DIFF
--- a/web/env/enterprise.js
+++ b/web/env/enterprise.js
@@ -1,7 +1,7 @@
 module.exports = {
   ENVIRONMENT: "production",
   SECURE_ADMIN_CONSOLE: true,
-  API_ENDPOINT: "//",
+  API_ENDPOINT: "//api/v1",
   SHIP_CLUSTER_BUILD_VERSION: (function () {
     return String(Date.now());
   }()),

--- a/web/env/enterprise.js
+++ b/web/env/enterprise.js
@@ -1,7 +1,7 @@
 module.exports = {
   ENVIRONMENT: "production",
   SECURE_ADMIN_CONSOLE: true,
-  API_ENDPOINT: "###_REST_ENDPOINT_###",
+  API_ENDPOINT: "//",
   SHIP_CLUSTER_BUILD_VERSION: (function () {
     return String(Date.now());
   }()),

--- a/web/kustomize/overlays/kotsadm/configmap.yaml
+++ b/web/kustomize/overlays/kotsadm/configmap.yaml
@@ -5,6 +5,4 @@ metadata:
 data:
   start-kotsadm-web.sh: |
     #!/bin/bash
-    sed -i 's/###_REST_ENDPOINT_###/https:\/\/{{repl ConfigOption "hostname"}}\/api/v1g' /usr/share/nginx/html/index.html
-
     nginx -g "daemon off;"


### PR DESCRIPTION
We always proxy the API behind web, so making this absolute is unnecessary.