### PR TITLE
Add api prefix for dev env

### DIFF
--- a/api/src/session/session_store.ts
+++ b/api/src/session/session_store.ts
@@ -12,7 +12,7 @@ export type InstallationMap = {
 };
 
 export class SessionStore {
-  constructor(private readonly pool: pg.Pool, private readonly params: Params) {}
+  constructor(private readonly pool: pg.Pool, private readonly params: Params) { }
 
   /**
    * Creates a signed JWT for authenticaion
@@ -74,6 +74,10 @@ export class SessionStore {
     //tslint:disable-next-line possible-timing-attack
     if (token.length > 0 && token !== "null") {
       try {
+        if (token.startsWith("Bearer ")) {
+          token = token.split(" ")[1];
+        }
+
         const decoded: any = jwt.verify(token, this.params.sessionKey);
 
         const session = await this.getSession(decoded.sessionId);

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -38,24 +38,26 @@ func Start() {
 	r.Path("/api/v1/troubleshoot/{appSlug}").Methods("GET").HandlerFunc(handlers.NodeProxy(upstream))
 	r.Path("/api/v1/troubleshoot/{appId}/{bundleId}").Methods("PUT").HandlerFunc(handlers.NodeProxy(upstream))
 
+	r.Path("/api/v1/troubleshoot/supportbundle/{bundleId}/download").Methods("GET").HandlerFunc(handlers.NodeProxy(upstream))
+
 	// Implemented handlers
-	r.HandleFunc("/v1/login", handlers.Login)
-	r.HandleFunc("/v1/logout", handlers.NotImplemented)
-	r.Path("/v1/metadata").Methods("OPTIONS", "GET").HandlerFunc(handlers.Metadata)
+	r.HandleFunc("/api/v1/login", handlers.Login)
+	r.HandleFunc("/api/v1/logout", handlers.NotImplemented)
+	r.Path("/api/v1/metadata").Methods("OPTIONS", "GET").HandlerFunc(handlers.Metadata)
 
 	// TODO
 
 	// KURL
-	r.HandleFunc("/v1/kurl", handlers.NotImplemented)
+	r.HandleFunc("/api/v1/kurl", handlers.NotImplemented)
 
 	// Prom
-	r.HandleFunc("/v1/prometheus", handlers.NotImplemented)
+	r.HandleFunc("/api/v1/prometheus", handlers.NotImplemented)
 
 	// GitOps
-	r.HandleFunc("/v1/gitops", handlers.NotImplemented)
+	r.HandleFunc("/api/v1/gitops", handlers.NotImplemented)
 
 	// License
-	r.HandleFunc("/v1/license", handlers.NotImplemented)
+	r.HandleFunc("/api/v1/license", handlers.NotImplemented)
 
 	// to avoid confusion, we don't serve this in the dev env...
 	if os.Getenv("DISABLE_SPA_SERVING") != "1" {

--- a/web/env/skaffold.js
+++ b/web/env/skaffold.js
@@ -1,7 +1,7 @@
 module.exports = {
   ENVIRONMENT: "development",
   SECURE_ADMIN_CONSOLE: true,
-  API_ENDPOINT: "http://localhost:30065/v1",
+  API_ENDPOINT: "http://localhost:30065/api/v1",
   GRAPHQL_ENDPOINT: "http://localhost:30065/graphql",
   SHIP_CLUSTER_BUILD_VERSION: (function () {
     return String(Date.now());


### PR DESCRIPTION
This addresses a few subtle bugs and challenges:

1. Our local dev environment didn't have the same URL prefix as prod installs. This caused some bugs to present only in one environment. Standardizing on a single path style between these envs will hopefully help.

2. In the move to the Go API, JWT tokens are now coming with a Bearer prefix. There's a change here for proxied requests to accept the bearer prefixed tokens.

3. Added a proxy for downloading support bundles