### PR TITLE
use AddCallerSkip so that logger.Error reports line of caller

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -7,7 +7,7 @@ import (
 var log *zap.Logger
 
 func init() {
-	l, err := zap.NewDevelopment()
+	l, err := zap.NewDevelopment(zap.AddCallerSkip(1))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
instead of reporting line within logger.go

so instead of `2020-01-22T21:27:40.210Z	ERROR	logger/logger.go:21	EOF` you'd get the actual source of the error