### PR TITLE
make config update for all pending app versions

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -30,6 +30,12 @@ type Downstream struct {
 	Name      string
 }
 
+type AppVersion struct {
+	Sequence     int
+	UpdateCursor int
+	VersionLabel string
+}
+
 func Get(id string) (*App, error) {
 	logger.Debug("getting app from id",
 		zap.String("id", id))
@@ -198,7 +204,13 @@ func (a App) createVersion(filesInDir string, source string, isFirstVersion bool
 
 	newSequence := 0
 	if !isFirstVersion {
-		newSequence = a.CurrentSequence + 1
+		// determine next available sequence for this app - we shouldn't assume that a.CurrentSequence is accurate
+		row := tx.QueryRow(`select max(sequence) from app_version where app_id = $1`, a.ID)
+		err = row.Scan(&newSequence)
+		if err != nil {
+			return 0, errors.Wrap(err, "failed to find current max sequence in row")
+		}
+		newSequence++
 	}
 
 	query := `insert into app_version (app_id, sequence, created_at, version_label, release_notes, update_cursor, channel_name, encryption_key,
@@ -247,7 +259,7 @@ backup_spec = EXCLUDED.backup_spec`
 	appIcon := kotsKinds.KotsApplication.Spec.Icon
 
 	query = "update app set current_sequence = $1, name = $2, icon_uri = $3 where id = $4"
-	_, err = tx.Exec(query, int64(a.CurrentSequence+1), appName, appIcon, a.ID)
+	_, err = tx.Exec(query, int64(newSequence), appName, appIcon, a.ID)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to update app")
 	}
@@ -331,4 +343,27 @@ backup_spec = EXCLUDED.backup_spec`
 	}
 
 	return int64(newSequence), nil
+}
+
+// return the list of versions available for an app
+func (a App) GetVersions() ([]AppVersion, error) {
+	db := persistence.MustGetPGSession()
+	query := `select sequence, update_cursor, version_label from app_version where app_id = $1 order by sequence asc`
+	rows, err := db.Query(query, a.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "query app_version table")
+	}
+
+	versions := []AppVersion{}
+
+	for rows.Next() {
+		rowVersion := AppVersion{}
+		err = rows.Scan(&rowVersion.Sequence, &rowVersion.UpdateCursor, &rowVersion.VersionLabel)
+		if err != nil {
+			return nil, errors.Wrap(err, "scan row from app_version table")
+		}
+		versions = append(versions, rowVersion)
+	}
+
+	return versions, nil
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -348,7 +348,7 @@ backup_spec = EXCLUDED.backup_spec`
 // return the list of versions available for an app
 func (a App) GetVersions() ([]AppVersion, error) {
 	db := persistence.MustGetPGSession()
-	query := `select sequence, update_cursor, version_label from app_version where app_id = $1 order by sequence asc`
+	query := `select sequence, update_cursor, version_label from app_version where app_id = $1 order by update_cursor asc, sequence asc`
 	rows, err := db.Query(query, a.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "query app_version table")

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -78,27 +78,43 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	archiveDir, err := app.GetAppVersionArchive(foundApp.ID, updateAppConfigRequest.Sequence)
+	resp, err := updateAppConfig(foundApp, updateAppConfigRequest.Sequence, updateAppConfigRequest)
 	if err != nil {
 		logger.Error(err)
-		updateAppConfigResponse.Error = "failed to get app version archive"
-		JSON(w, 500, updateAppConfigResponse)
+		JSON(w, 500, resp)
 		return
+	}
+
+	if len(resp.RequiredItems) > 0 {
+		JSON(w, 400, resp)
+		return
+	}
+
+	JSON(w, 200, resp)
+}
+
+func updateAppConfig(updateApp *app.App, seq int, req UpdateAppConfigRequest) (UpdateAppConfigResponse, error) {
+	updateAppConfigResponse := UpdateAppConfigResponse{
+		Success: false,
+	}
+
+	archiveDir, err := app.GetAppVersionArchive(updateApp.ID, req.Sequence)
+	if err != nil {
+		updateAppConfigResponse.Error = "failed to get app version archive"
+		return updateAppConfigResponse, err
 	}
 	defer os.RemoveAll(archiveDir)
 
 	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
 	if err != nil {
-		logger.Error(err)
 		updateAppConfigResponse.Error = "failed to load kots kinds from path"
-		JSON(w, 500, updateAppConfigResponse)
-		return
+		return updateAppConfigResponse, err
 	}
 
 	// check for unset required items
 	requiredItems := make([]string, 0, 0)
 	requiredItemsTitles := make([]string, 0, 0)
-	for _, group := range updateAppConfigRequest.ConfigGroups {
+	for _, group := range req.ConfigGroups {
 		for _, item := range group.Items {
 			if app.IsRequiredItem(item) && app.IsUnsetItem(item) {
 				requiredItems = append(requiredItems, item.Name)
@@ -117,14 +133,13 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 			Error:         fmt.Sprintf("The following fields are required: %s", strings.Join(requiredItemsTitles, ", ")),
 			RequiredItems: requiredItems,
 		}
-		JSON(w, 400, updateAppConfigResponse)
-		return
+		return updateAppConfigResponse, nil
 	}
 
 	// we don't merge, this is a wholesale replacement of the config values
 	// so we don't need the complex logic in kots, we can just write
 	values := kotsKinds.ConfigValues.Spec.Values
-	for _, group := range updateAppConfigRequest.ConfigGroups {
+	for _, group := range req.ConfigGroups {
 		for _, item := range group.Items {
 			if item.Value.Type == multitype.Bool {
 				updatedValue := item.Value.BoolVal
@@ -137,10 +152,8 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 					// encrypt using the key
 					cipher, err := crypto.AESCipherFromString(kotsKinds.Installation.Spec.EncryptionKey)
 					if err != nil {
-						logger.Error(err)
 						updateAppConfigResponse.Error = "failed to get encryption cipher"
-						JSON(w, 500, updateAppConfigResponse)
-						return
+						return updateAppConfigResponse, err
 					}
 
 					// if the decryption succeeds, don't encrypt again
@@ -158,87 +171,66 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if kotsKinds.ConfigValues == nil {
-		logger.Error(errors.New("no config values found"))
 		updateAppConfigResponse.Error = "no config values found"
-		JSON(w, 500, updateAppConfigResponse)
-		return
+		return updateAppConfigResponse, errors.New("no config values found")
 	}
 
 	kotsKinds.ConfigValues.Spec.Values = values
 
 	configValuesSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "ConfigValues")
 	if err != nil {
-		logger.Error(err)
 		updateAppConfigResponse.Error = "failed to marshal config values spec"
-		JSON(w, 500, updateAppConfigResponse)
-		return
+		return updateAppConfigResponse, err
 	}
 
 	if err := ioutil.WriteFile(filepath.Join(archiveDir, "upstream", "userdata", "config.yaml"), []byte(configValuesSpec), 0644); err != nil {
-		logger.Error(err)
 		updateAppConfigResponse.Error = "failed to write config.yaml to upstream/userdata"
-		JSON(w, 500, updateAppConfigResponse)
-		return
+		return updateAppConfigResponse, err
 	}
 
-	err = foundApp.RenderDir(archiveDir)
+	err = updateApp.RenderDir(archiveDir)
 	if err != nil {
-		logger.Error(err)
 		updateAppConfigResponse.Error = "failed to render archive directory"
-		JSON(w, 500, updateAppConfigResponse)
-		return
+		return updateAppConfigResponse, err
 	}
 
-	if updateAppConfigRequest.CreateNewVersion {
-		newSequence, err := foundApp.CreateVersion(archiveDir, "Config Change")
+	if req.CreateNewVersion {
+		newSequence, err := updateApp.CreateVersion(archiveDir, "Config Change")
 		if err != nil {
-			logger.Error(err)
 			updateAppConfigResponse.Error = "failed to create an app version"
-			JSON(w, 500, updateAppConfigResponse)
-			return
+			return updateAppConfigResponse, err
 		}
 
-		if err := app.CreateAppVersionArchive(foundApp.ID, newSequence, archiveDir); err != nil {
-			logger.Error(err)
+		if err := app.CreateAppVersionArchive(updateApp.ID, newSequence, archiveDir); err != nil {
 			updateAppConfigResponse.Error = "failed to create an app version archive"
-			JSON(w, 500, updateAppConfigResponse)
-			return
+			return updateAppConfigResponse, err
 		}
 	} else {
-		if err := app.UpdateConfigValuesInDB(archiveDir, foundApp.ID, int64(updateAppConfigRequest.Sequence)); err != nil {
-			logger.Error(err)
+		if err := app.UpdateConfigValuesInDB(archiveDir, updateApp.ID, int64(req.Sequence)); err != nil {
 			updateAppConfigResponse.Error = "failed to update config values in db"
-			JSON(w, 500, updateAppConfigResponse)
-			return
+			return updateAppConfigResponse, err
 		}
 
 		if kotsKinds.Preflight != nil {
-			if err := app.SetDownstreamVersionPendingPreflight(foundApp.ID, int64(updateAppConfigRequest.Sequence)); err != nil {
-				logger.Error(err)
+			if err := app.SetDownstreamVersionPendingPreflight(updateApp.ID, int64(req.Sequence)); err != nil {
 				updateAppConfigResponse.Error = "failed to set downstream version pending preflight"
-				JSON(w, 500, updateAppConfigResponse)
-				return
+				return updateAppConfigResponse, err
 			}
 		} else {
-			if err := app.SetDownstreamVersionReady(foundApp.ID, int64(updateAppConfigRequest.Sequence)); err != nil {
-				logger.Error(err)
+			if err := app.SetDownstreamVersionReady(updateApp.ID, int64(req.Sequence)); err != nil {
 				updateAppConfigResponse.Error = "failed to set downstream version ready"
-				JSON(w, 500, updateAppConfigResponse)
-				return
+				return updateAppConfigResponse, err
 			}
 		}
 
-		if err := app.CreateAppVersionArchive(foundApp.ID, int64(updateAppConfigRequest.Sequence), archiveDir); err != nil {
-			logger.Error(err)
+		if err := app.CreateAppVersionArchive(updateApp.ID, int64(req.Sequence), archiveDir); err != nil {
 			updateAppConfigResponse.Error = "failed to create app version archive"
-			JSON(w, 500, updateAppConfigResponse)
-			return
+			return updateAppConfigResponse, err
 		}
 	}
 
 	updateAppConfigResponse.Success = true
-
-	JSON(w, 200, updateAppConfigResponse)
+	return updateAppConfigResponse, nil
 }
 
 func decrypt(input string, cipher *crypto.AESCipher) (string, error) {

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -291,7 +292,7 @@ func decrypt(input string, cipher *crypto.AESCipher) (string, error) {
 	return string(decrypted), nil
 }
 
-func getLaterVersions(versionedApp *app.App, startSeq int) (int, map[int]app.AppVersion, error) {
+func getLaterVersions(versionedApp *app.App, startSeq int) (int, []app.AppVersion, error) {
 	versions, err := versionedApp.GetVersions()
 	if err != nil {
 		return -1, nil, errors.Wrap(err, "failed to get app versions")
@@ -324,5 +325,17 @@ func getLaterVersions(versionedApp *app.App, startSeq int) (int, map[int]app.App
 		}
 	}
 
-	return latestSequenceWithUpdateCursor, laterVersions, nil
+	// ensure that the returned versions array is sorted by GVK
+	keys := []int{}
+	for key, _ := range laterVersions {
+		keys = append(keys, key)
+	}
+	sort.Ints(keys)
+
+	sortedVersions := []app.AppVersion{}
+	for _, key := range keys {
+		sortedVersions = append(sortedVersions, laterVersions[key])
+	}
+
+	return latestSequenceWithUpdateCursor, sortedVersions, nil
 }

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -169,10 +169,10 @@ func updateAppConfig(updateApp *app.App, seq int, req UpdateAppConfigRequest, is
 			}
 		}
 	}
-	updateAppConfigResponse.RequiredItems = requiredItems
 
 	// not having all the required items is only a failure for the version that the user intended to edit
 	if len(requiredItems) > 0 && isPrimaryVersion {
+		updateAppConfigResponse.RequiredItems = requiredItems
 		updateAppConfigResponse.Error = fmt.Sprintf("The following fields are required: %s", strings.Join(requiredItemsTitles, ", "))
 		return updateAppConfigResponse, nil
 	}


### PR DESCRIPTION
if the config page expects version x, but there's a newer version x+1, check if they share the same underlying upstream version
if they do, then make an update based on x+1 (and fail if missing required items)
if they do not, make an update based on x (and fail if missing required items) AND an update based on x+1 (that does not fail if missing required items, and instead adds the version as `pending_config`)