### PR TITLE
Run preflights inline

### DIFF
--- a/api/src/sockets/kots/DeploySocket.ts
+++ b/api/src/sockets/kots/DeploySocket.ts
@@ -51,7 +51,7 @@ export class KotsDeploySocketService {
             this.troubleshootStore = new TroubleshootStore(pool, params);
             this.clusterSocketHistory = [];
 
-            setInterval(this.preflightLoop.bind(this), 1000);
+            setInterval(this.deployLoop.bind(this), 1000);
             setInterval(this.supportBundleLoop.bind(this), 1000);
             setInterval(this.restoreLoop.bind(this), 1000);
           })
@@ -249,7 +249,7 @@ export class KotsDeploySocketService {
   }
 
   // tslint:disable-next-line cyclomatic-complexity
-  async preflightLoop() {
+  async deployLoop() {
     if (!this.clusterSocketHistory) {
       return;
     }
@@ -259,17 +259,6 @@ export class KotsDeploySocketService {
       for (const app of apps) {
         if (app.restoreInProgressName) {
           continue;
-        }
-        const pendingPreflightParams = await this.preflightStore.getPendingPreflightParams(true);
-        for (const param of pendingPreflightParams) {
-          if (clusterSocketHistory.sentPreflightUrls[param.url] !== param.ignorePermissions) {
-            const msg = {
-              uri: param.url,
-              ignorePermissions: param.ignorePermissions
-            }
-            this.io.in(clusterSocketHistory.clusterId).emit("preflight", msg);
-            clusterSocketHistory.sentPreflightUrls[param.url] = param.ignorePermissions;
-          }
         }
 
         const deployedAppVersion = await this.kotsAppStore.getCurrentVersion(app.id, clusterSocketHistory.clusterId);

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,20 @@ module github.com/replicatedhq/kotsadm
 go 1.12
 
 require (
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aws/aws-sdk-go v1.25.18
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/frankban/quicktest v1.7.3 // indirect
+	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.0
+	github.com/huandu/xstrings v1.3.0 // indirect
 	github.com/kubernetes-sigs/application v0.8.1 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kots v1.13.6
-	github.com/replicatedhq/kotsadm/operator v0.0.0-20200312204205-5dc8b8fe1538 // indirect
 	github.com/replicatedhq/troubleshoot v0.9.27-0.20200310173216-983aaaacea80
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/segmentio/ksuid v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/aws/aws-sdk-go v1.25.18
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/frankban/quicktest v1.7.3 // indirect
-	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.0
 	github.com/kubernetes-sigs/application v0.8.1 // indirect
@@ -15,7 +14,8 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kots v1.13.6
-	github.com/replicatedhq/troubleshoot v0.9.26
+	github.com/replicatedhq/kotsadm/operator v0.0.0-20200312204205-5dc8b8fe1538 // indirect
+	github.com/replicatedhq/troubleshoot v0.9.27-0.20200310173216-983aaaacea80
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/segmentio/ksuid v1.0.2
 	github.com/sergi/go-diff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
-github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -612,8 +610,6 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
-github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
-github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -697,8 +693,6 @@ github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/pact-foundation/pact-go v1.0.0-beta.5 h1:pTm7BOQ/karCyvZQtRk9lwJ7ZEK5rF+ocdcd5oZFkXc=
-github.com/pact-foundation/pact-go v1.0.0-beta.5/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -751,8 +745,6 @@ github.com/replicatedhq/kots v1.13.3 h1:AnraOU2iAqfkkLRD6wujX30Sr+OG37lPqldZRRKF
 github.com/replicatedhq/kots v1.13.3/go.mod h1:wI3W7ksjw8IupLA3m4gGJ79fWZIhSJfU/SaPZqm9pVA=
 github.com/replicatedhq/kots v1.13.6 h1:zN9hQoOT8GHXLSleNtwUfMDE0nwUm4OcVctHaB5dNg0=
 github.com/replicatedhq/kots v1.13.6/go.mod h1:hIjcm5uIBP7LZ0O7S+SJqw2Esw8NQbAgwpL9oHiGTA8=
-github.com/replicatedhq/kotsadm/operator v0.0.0-20200312204205-5dc8b8fe1538 h1:t7BWS3ukuFZ3yBrCn5c0d8wRRquHgtXXaepEON9ZWk4=
-github.com/replicatedhq/kotsadm/operator v0.0.0-20200312204205-5dc8b8fe1538/go.mod h1:NSqt331XhUNgvyb3/THH6lCnpB1NNM+7eGWWM4acW3U=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
 github.com/replicatedhq/troubleshoot v0.9.26 h1:zd/Umkad5NVr5A5sB8JR/gAicTiwDO0am87qgvlTZyY=
@@ -1177,6 +1169,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.36.0/go.mod h1:RUoy9p/M4ge0HzT8L+SDZ8jg+Q6fth0CiBuhFJpSV40=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl+fi1br7+Rr3LqpNJf1/uxUdtRUV+Tnj0o93V2B9MU=
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
@@ -34,6 +35,8 @@ github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RP
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.0.2 h1:tRi7ENs+AaOUCH+j6qwNQgPYfV26dX3JNonq+V4mhqc=
 github.com/Masterminds/semver/v3 v3.0.2/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
@@ -63,6 +66,7 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412 h1:vOVO0ypMfTt6tZacyI0kp+iCZb1XSNiYDqnzBWYgfe4=
 github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412/go.mod h1:AI9hp1tkp10pAlK5TCwL+7yWbRgtDm9jhToq6qij2xs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
@@ -96,6 +100,7 @@ github.com/beevik/ntp v0.2.0 h1:sGsd+kAXzT0bfVfzJfce04g+dSRfrs+tbQW8lweuYgw=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
@@ -243,6 +248,7 @@ github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3 h1:t8FVkw33L+wilf2
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0 h1:3tMoCCfM7ppqsR0ptz/wi1impNpT7/9wQtMZ8lr1mCQ=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
+github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
 github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
@@ -342,6 +348,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -399,6 +406,7 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -411,6 +419,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
+github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
@@ -443,12 +452,16 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-getter v1.3.1-0.20190627223108-da0323b9545e h1:6krcdHPiS+aIP9XKzJzSahfjD7jG7Z+4+opm0z39V1M=
 github.com/hashicorp/go-getter v1.3.1-0.20190627223108-da0323b9545e/go.mod h1:/O1k/AizTN0QmfEKknCYGvICeyKUDqCYA8vvWtGWDeQ=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
+github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -457,6 +470,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
+github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -464,6 +479,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/huandu/xstrings v1.2.1 h1:v6IdmkCnDhJG/S0ivr58PeIfg+tyhqQYy4YsCsQ0Pdc=
 github.com/huandu/xstrings v1.2.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/huandu/xstrings v1.3.0 h1:gvV6jG9dTgFEncxo+AF7PH6MZXi/vZl25owA/8Dg8Wo=
+github.com/huandu/xstrings v1.3.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -566,6 +583,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.10 h1:Y7Xqm8piKOO3v10Thp7Z36h4FYFjt5xB//6XvOrs2Gw=
@@ -589,9 +607,13 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
 github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
+github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
+github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -627,6 +649,7 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=
 github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
@@ -674,6 +697,8 @@ github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/pact-foundation/pact-go v1.0.0-beta.5 h1:pTm7BOQ/karCyvZQtRk9lwJ7ZEK5rF+ocdcd5oZFkXc=
+github.com/pact-foundation/pact-go v1.0.0-beta.5/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -726,9 +751,15 @@ github.com/replicatedhq/kots v1.13.3 h1:AnraOU2iAqfkkLRD6wujX30Sr+OG37lPqldZRRKF
 github.com/replicatedhq/kots v1.13.3/go.mod h1:wI3W7ksjw8IupLA3m4gGJ79fWZIhSJfU/SaPZqm9pVA=
 github.com/replicatedhq/kots v1.13.6 h1:zN9hQoOT8GHXLSleNtwUfMDE0nwUm4OcVctHaB5dNg0=
 github.com/replicatedhq/kots v1.13.6/go.mod h1:hIjcm5uIBP7LZ0O7S+SJqw2Esw8NQbAgwpL9oHiGTA8=
+github.com/replicatedhq/kotsadm/operator v0.0.0-20200312204205-5dc8b8fe1538 h1:t7BWS3ukuFZ3yBrCn5c0d8wRRquHgtXXaepEON9ZWk4=
+github.com/replicatedhq/kotsadm/operator v0.0.0-20200312204205-5dc8b8fe1538/go.mod h1:NSqt331XhUNgvyb3/THH6lCnpB1NNM+7eGWWM4acW3U=
+github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
 github.com/replicatedhq/troubleshoot v0.9.26 h1:zd/Umkad5NVr5A5sB8JR/gAicTiwDO0am87qgvlTZyY=
+github.com/replicatedhq/troubleshoot v0.9.26 h1:zd/Umkad5NVr5A5sB8JR/gAicTiwDO0am87qgvlTZyY=
 github.com/replicatedhq/troubleshoot v0.9.26/go.mod h1:7MyY22gXMXTp1cUczegcXUeMsUJhtMzrrmlAi0aJu4s=
+github.com/replicatedhq/troubleshoot v0.9.27-0.20200310173216-983aaaacea80 h1:M0fiwncuiAQUa7QPc5OrHwE1JxWRyBx4jpSw55GgJGI=
+github.com/replicatedhq/troubleshoot v0.9.27-0.20200310173216-983aaaacea80/go.mod h1:7MyY22gXMXTp1cUczegcXUeMsUJhtMzrrmlAi0aJu4s=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq/go.mod h1:Txa7LopbYCU8aRgmNe0n+y/EPMz50NbCPcVVJBquwag=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
@@ -785,6 +816,7 @@ github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUr
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
@@ -848,8 +880,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 h1:vY5WqiEon0ZSTGM3ayVVi+twaHKHDFUVloaQ/wug9/c=
 github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9/go.mod h1:q+QjxYvZ+fpjMXqs+XEriussHjSYqeXVnAdSV1tkMYk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
@@ -1113,6 +1147,7 @@ google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.1.0/go.mod h1:UGEZY7KEX120AnNLIHFMKIo4obdJhkp2tPbaPlQx13Y=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.6.1-0.20190607001116-5213b8090861 h1:ppLucX0K/60T3t6LPZQzTOkt5PytkEbQLIaSteq+TpE=
 google.golang.org/api v0.6.1-0.20190607001116-5213b8090861/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1130,6 +1165,7 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
@@ -1139,6 +1175,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
@@ -1159,6 +1196,7 @@ gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
+gopkg.in/go-playground/validator.v8 v8.18.2 h1:lFB4DoMU6B626w8ny76MV7VX6W2VHct2GVOI3xgiMrQ=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/go.sum
+++ b/go.sum
@@ -745,6 +745,7 @@ github.com/replicatedhq/kots v1.13.3 h1:AnraOU2iAqfkkLRD6wujX30Sr+OG37lPqldZRRKF
 github.com/replicatedhq/kots v1.13.3/go.mod h1:wI3W7ksjw8IupLA3m4gGJ79fWZIhSJfU/SaPZqm9pVA=
 github.com/replicatedhq/kots v1.13.6 h1:zN9hQoOT8GHXLSleNtwUfMDE0nwUm4OcVctHaB5dNg0=
 github.com/replicatedhq/kots v1.13.6/go.mod h1:hIjcm5uIBP7LZ0O7S+SJqw2Esw8NQbAgwpL9oHiGTA8=
+github.com/replicatedhq/kots v1.13.9 h1:wo8ZJNsYn1TMrwtsQ5c+bREj+7XT+Tbf8Yr4UO3ZTcA=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
 github.com/replicatedhq/troubleshoot v0.9.26 h1:zd/Umkad5NVr5A5sB8JR/gAicTiwDO0am87qgvlTZyY=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,11 +2,9 @@ package app
 
 import (
 	"database/sql"
-	"encoding/json"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
 	"github.com/replicatedhq/kotsadm/pkg/logger"
 	"github.com/replicatedhq/kotsadm/pkg/persistence"
 	"go.uber.org/zap"
@@ -18,22 +16,8 @@ type App struct {
 	Name            string
 	IsAirgap        bool
 	CurrentSequence int64
-	Downstreams     []*Downstream
 
 	// Additional fields will be added here as implementation is moved from node to go
-
-	RegistrySettings *RegistrySettings
-}
-
-type Downstream struct {
-	ClusterID string
-	Name      string
-}
-
-type AppVersion struct {
-	Sequence     int64
-	UpdateCursor int
-	VersionLabel string
 }
 
 func Get(id string) (*App, error) {
@@ -41,31 +25,15 @@ func Get(id string) (*App, error) {
 		zap.String("id", id))
 
 	db := persistence.MustGetPGSession()
-	query := `select id, slug, name, current_sequence, is_airgap, registry_hostname, registry_username, registry_password_enc, namespace from app where id = $1`
+	query := `select id, slug, name, current_sequence, is_airgap from app where id = $1`
 	row := db.QueryRow(query, id)
 
 	app := App{}
 
-	var registryHostname sql.NullString
-	var registryUsername sql.NullString
-	var registryPasswordEnc sql.NullString
-	var registryNamespace sql.NullString
 	var currentSequence sql.NullInt64
 
-	if err := row.Scan(&app.ID, &app.Slug, &app.Name, &currentSequence, &app.IsAirgap,
-		&registryHostname, &registryUsername, &registryPasswordEnc, &registryNamespace); err != nil {
+	if err := row.Scan(&app.ID, &app.Slug, &app.Name, &currentSequence, &app.IsAirgap); err != nil {
 		return nil, errors.Wrap(err, "failed to scan app")
-	}
-
-	if registryHostname.Valid {
-		registrySettings := RegistrySettings{
-			Hostname:    registryHostname.String,
-			Username:    registryUsername.String,
-			PasswordEnc: registryPasswordEnc.String,
-			Namespace:   registryNamespace.String,
-		}
-
-		app.RegistrySettings = &registrySettings
 	}
 
 	if currentSequence.Valid {
@@ -73,23 +41,6 @@ func Get(id string) (*App, error) {
 	} else {
 		app.CurrentSequence = -1
 	}
-
-	query = `select cluster_id, downstream_name from app_downstream where app_id = $1`
-	rows, err := db.Query(query, id)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get downstreams")
-	}
-
-	downstreams := []*Downstream{}
-	for rows.Next() {
-		downstream := Downstream{}
-		if err := rows.Scan(&downstream.ClusterID, &downstream.Name); err != nil {
-			return nil, errors.Wrap(err, "failed to scan downstream")
-		}
-
-		downstreams = append(downstreams, &downstream)
-	}
-	app.Downstreams = downstreams
 
 	return &app, nil
 }
@@ -121,267 +72,4 @@ func LastUpdateAtTime(appID string) error {
 	}
 
 	return nil
-}
-
-// SetDownstreamVersionReady sets the status for the downstream version with the given sequence and app id to "pending"
-func SetDownstreamVersionReady(appID string, sequence int64) error {
-	db := persistence.MustGetPGSession()
-	query := `update app_downstream_version set status = 'pending' where app_id = $1 and sequence = $2`
-	_, err := db.Exec(query, appID, sequence)
-	if err != nil {
-		return errors.Wrap(err, "failed to set downstream version ready")
-	}
-
-	return nil
-}
-
-// SetDownstreamVersionPendingPreflight sets the status for the downstream version with the given sequence and app id to "pending_preflight"
-func SetDownstreamVersionPendingPreflight(appID string, sequence int64) error {
-	db := persistence.MustGetPGSession()
-	query := `update app_downstream_version set status = 'pending_preflight' where app_id = $1 and sequence = $2`
-	_, err := db.Exec(query, appID, sequence)
-	if err != nil {
-		return errors.Wrap(err, "failed to set downstream version pending preflight")
-	}
-
-	return nil
-}
-
-// CreateFirstVersion works much likst CreateVersion except that it assumes version 0
-// and never attempts to calculate a diff, or look at previous versions
-func (a App) CreateFirstVersion(filesInDir string, source string) (int64, error) {
-	return a.createVersion(filesInDir, source, true)
-}
-
-// CreateVersion creates a new version of the app in the database, but the caller
-// is responsible for uploading the archive to s3
-func (a App) CreateVersion(filesInDir string, source string) (int64, error) {
-	return a.createVersion(filesInDir, source, false)
-}
-
-// this is the common, internal function to create an app version, used in both
-// new and updates to apps
-func (a App) createVersion(filesInDir string, source string, isFirstVersion bool) (int64, error) {
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filesInDir)
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to read kots kinds")
-	}
-
-	supportBundleSpec, err := kotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Collector")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal support bundle spec")
-	}
-	analyzersSpec, err := kotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Analyzer")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal analyzer spec")
-	}
-	preflightSpec, err := kotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Preflight")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal preflight spec")
-	}
-
-	appSpec, err := kotsKinds.Marshal("app.k8s.io", "v1beta1", "Application")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal app spec")
-	}
-	kotsAppSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Application")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal kots app spec")
-	}
-	backupSpec, err := kotsKinds.Marshal("velero.io", "v1", "Backup")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal backup spec")
-	}
-
-	licenseSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "License")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal license spec")
-	}
-	configSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Config")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal config spec")
-	}
-	configValuesSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "ConfigValues")
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to marshal configvalues spec")
-	}
-
-	preflightBytes, err := a.RenderFile(kotsKinds, []byte(preflightSpec))
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to template preflight spec")
-	}
-	templatedPreflight := string(preflightBytes)
-
-	db := persistence.MustGetPGSession()
-
-	tx, err := db.Begin()
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to begin")
-	}
-	defer tx.Rollback()
-
-	newSequence := 0
-	if !isFirstVersion {
-		// determine next available sequence for this app - we shouldn't assume that a.CurrentSequence is accurate
-		row := tx.QueryRow(`select max(sequence) from app_version where app_id = $1`, a.ID)
-		err = row.Scan(&newSequence)
-		if err != nil {
-			return 0, errors.Wrap(err, "failed to find current max sequence in row")
-		}
-		newSequence++
-	}
-
-	query := `insert into app_version (app_id, sequence, created_at, version_label, release_notes, update_cursor, channel_name, encryption_key,
-supportbundle_spec, analyzer_spec, preflight_spec, app_spec, kots_app_spec, kots_license, config_spec, config_values, backup_spec)
-values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-ON CONFLICT(app_id, sequence) DO UPDATE SET
-created_at = EXCLUDED.created_at,
-version_label = EXCLUDED.version_label,
-release_notes = EXCLUDED.release_notes,
-update_cursor = EXCLUDED.update_cursor,
-channel_name = EXCLUDED.channel_name,
-encryption_key = EXCLUDED.encryption_key,
-supportbundle_spec = EXCLUDED.supportbundle_spec,
-analyzer_spec = EXCLUDED.analyzer_spec,
-preflight_spec = EXCLUDED.preflight_spec,
-app_spec = EXCLUDED.app_spec,
-kots_app_spec = EXCLUDED.kots_app_spec,
-kots_license = EXCLUDED.kots_license,
-config_spec = EXCLUDED.config_spec,
-config_values = EXCLUDED.config_values,
-backup_spec = EXCLUDED.backup_spec`
-	_, err = tx.Exec(query, a.ID, newSequence, time.Now(),
-		kotsKinds.Installation.Spec.VersionLabel,
-		kotsKinds.Installation.Spec.ReleaseNotes,
-		kotsKinds.Installation.Spec.UpdateCursor,
-		kotsKinds.Installation.Spec.ChannelName,
-		kotsKinds.Installation.Spec.EncryptionKey,
-		supportBundleSpec,
-		analyzersSpec,
-		templatedPreflight,
-		appSpec,
-		kotsAppSpec,
-		licenseSpec,
-		configSpec,
-		configValuesSpec,
-		backupSpec)
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to insert app version")
-	}
-
-	appName := kotsKinds.KotsApplication.Spec.Title
-	if appName == "" {
-		appName = a.Name
-	}
-
-	appIcon := kotsKinds.KotsApplication.Spec.Icon
-
-	query = "update app set current_sequence = $1, name = $2, icon_uri = $3 where id = $4"
-	_, err = tx.Exec(query, int64(newSequence), appName, appIcon, a.ID)
-	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to update app")
-	}
-
-	previousArchiveDir := ""
-	if !isFirstVersion {
-		// Get the previous archive, we need this to calculate the diff
-		previousDir, err := GetAppVersionArchive(a.ID, a.CurrentSequence)
-		if err != nil {
-			return int64(0), errors.Wrap(err, "failed to get previous archive")
-		}
-
-		previousArchiveDir = previousDir
-	}
-
-	for _, downstream := range a.Downstreams {
-		downstreamStatus := "pending"
-		if isFirstVersion && kotsKinds.Config != nil {
-			downstreamStatus = "pending_config"
-		} else if kotsKinds.Preflight != nil {
-			downstreamStatus = "pending_preflight"
-		}
-
-		diffSummary := ""
-		if !isFirstVersion {
-			// diff this release from the last release
-			diff, err := diffAppVersionsForDownstreams(downstream.Name, filesInDir, previousArchiveDir)
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to diff")
-			}
-			b, err := json.Marshal(diff)
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to marshal diff")
-			}
-			diffSummary = string(b)
-
-			// check if version needs additional configuration
-			t, err := needsConfiguration(configSpec, configValuesSpec, licenseSpec)
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to check if version needs configuration")
-			}
-			if t {
-				downstreamStatus = "pending_config"
-			}
-		}
-
-		commitURL := ""
-		query = `select max(sequence) from app_downstream_version where app_id = $1 and cluster_id = $2`
-		row := tx.QueryRow(query, a.ID, downstream.ClusterID)
-
-		lastDownstreamSequence := int64(-1)
-		if err := row.Scan(&lastDownstreamSequence); err != nil {
-			// continue, it's 0
-		}
-		newSequence := lastDownstreamSequence + 1
-
-		downstreamGitOps, err := GetDownstreamGitOps(a.ID, downstream.ClusterID)
-		if err != nil {
-			return int64(0), errors.Wrap(err, "failed to get downstream gitops")
-		}
-		if downstreamGitOps != nil {
-			createdCommitURL, err := createGitOpsCommit(downstreamGitOps, a.Slug, a.Name, int(newSequence), filesInDir, downstream.Name)
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to create gitops commit")
-			}
-
-			commitURL = createdCommitURL
-		}
-
-		query = `insert into app_downstream_version (app_id, cluster_id, sequence, parent_sequence, created_at, version_label, status, source, diff_summary, git_commit_url, git_deployable) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
-		_, err = tx.Exec(query, a.ID, downstream.ClusterID, newSequence, newSequence, time.Now(),
-			kotsKinds.Installation.Spec.VersionLabel, downstreamStatus, source,
-			diffSummary, commitURL, commitURL != "")
-		if err != nil {
-			return int64(0), errors.Wrap(err, "failed to create downstream version")
-		}
-	}
-
-	if err = tx.Commit(); err != nil {
-		return int64(0), errors.Wrap(err, "failed to commit")
-	}
-
-	return int64(newSequence), nil
-}
-
-// return the list of versions available for an app
-func (a App) GetVersions() ([]AppVersion, error) {
-	db := persistence.MustGetPGSession()
-	query := `select sequence, update_cursor, version_label from app_version where app_id = $1 order by update_cursor asc, sequence asc`
-	rows, err := db.Query(query, a.ID)
-	if err != nil {
-		return nil, errors.Wrap(err, "query app_version table")
-	}
-
-	versions := []AppVersion{}
-
-	for rows.Next() {
-		rowVersion := AppVersion{}
-		err = rows.Scan(&rowVersion.Sequence, &rowVersion.UpdateCursor, &rowVersion.VersionLabel)
-		if err != nil {
-			return nil, errors.Wrap(err, "scan row from app_version table")
-		}
-		versions = append(versions, rowVersion)
-	}
-
-	return versions, nil
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -17,7 +17,7 @@ type App struct {
 	Slug            string
 	Name            string
 	IsAirgap        bool
-	CurrentSequence int
+	CurrentSequence int64
 	Downstreams     []*Downstream
 
 	// Additional fields will be added here as implementation is moved from node to go
@@ -31,7 +31,7 @@ type Downstream struct {
 }
 
 type AppVersion struct {
-	Sequence     int
+	Sequence     int64
 	UpdateCursor int
 	VersionLabel string
 }
@@ -69,7 +69,7 @@ func Get(id string) (*App, error) {
 	}
 
 	if currentSequence.Valid {
-		app.CurrentSequence = int(currentSequence.Int64)
+		app.CurrentSequence = currentSequence.Int64
 	} else {
 		app.CurrentSequence = -1
 	}

--- a/pkg/app/archive.go
+++ b/pkg/app/archive.go
@@ -79,7 +79,7 @@ func CreateAppVersionArchive(appID string, sequence int64, archivePath string) e
 
 // GetAppVersionArchive will fetch the archive and return a string that contains a
 // directory name where it's extracted into
-func GetAppVersionArchive(appID string, sequence int) (string, error) {
+func GetAppVersionArchive(appID string, sequence int64) (string, error) {
 	tmpDir, err := ioutil.TempDir("", "kotsadm")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")

--- a/pkg/app/render.go
+++ b/pkg/app/render.go
@@ -11,23 +11,15 @@ import (
 	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/rewrite"
 	"github.com/replicatedhq/kots/pkg/template"
-	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
-	yaml "github.com/replicatedhq/yaml/v3"
 )
 
 // RenderFile renders a single file
 // this is useful for upstream/kotskinds files that are not rendered in the dir
 func (a *App) RenderFile(kotsKinds *kotsutil.KotsKinds, inputContent []byte) ([]byte, error) {
-
-	yamlObj := map[string]interface{}{}
-	err := yaml.Unmarshal(inputContent, &yamlObj)
+	inputContent, err := kotsutil.FixUpYAML(inputContent)
 	if err != nil {
-		return nil, err
-	}
-	inputContent, err = util.MarshalIndent(2, yamlObj)
-	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to fix up yaml")
 	}
 
 	apiCipher, err := crypto.AESCipherFromString(os.Getenv("API_ENCRYPTION_KEY"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-package app
+package config
 
 import (
 	"github.com/pkg/errors"
@@ -31,7 +31,7 @@ func IsUnsetItem(item kotsv1beta1.ConfigItem) bool {
 	return true
 }
 
-func needsConfiguration(configSpec string, configValuesSpec string, licenseSpec string) (bool, error) {
+func NeedsConfiguration(configSpec string, configValuesSpec string, licenseSpec string) (bool, error) {
 	if configSpec == "" {
 		return false, nil
 	}

--- a/pkg/downstream/diff.go
+++ b/pkg/downstream/diff.go
@@ -1,4 +1,4 @@
-package app
+package downstream
 
 import (
 	"bufio"
@@ -40,7 +40,7 @@ func diffContent(updatedContent string, baseContent string) (int, int, error) {
 	return additions, deletions, nil
 }
 
-func diffAppVersionsForDownstreams(downstreamName string, archive string, diffBasePath string) (*Diff, error) {
+func DiffAppVersionsForDownstreams(downstreamName string, archive string, diffBasePath string) (*Diff, error) {
 	rootPathsToInclude := []string{
 		"base",
 		filepath.Join("overlays", "midstream"),

--- a/pkg/downstream/diff_test.go
+++ b/pkg/downstream/diff_test.go
@@ -1,11 +1,11 @@
-package app
+package downstream
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/go-playground/assert.v1"
 	_ "go.undefinedlabs.com/scopeagent/autoinstrument"
+	"gopkg.in/go-playground/assert.v1"
 )
 
 func Test_diffContent(t *testing.T) {

--- a/pkg/downstream/downstream.go
+++ b/pkg/downstream/downstream.go
@@ -1,0 +1,52 @@
+package downstream
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/downstream/types"
+	"github.com/replicatedhq/kotsadm/pkg/persistence"
+)
+
+func ListDownstreamsForApp(appID string) ([]*types.Downstream, error) {
+	db := persistence.MustGetPGSession()
+	query := `select cluster_id, downstream_name from app_downstream where app_id = $1`
+	rows, err := db.Query(query, appID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get downstreams")
+	}
+
+	downstreams := []*types.Downstream{}
+	for rows.Next() {
+		downstream := types.Downstream{}
+		if err := rows.Scan(&downstream.ClusterID, &downstream.Name); err != nil {
+			return nil, errors.Wrap(err, "failed to scan downstream")
+		}
+
+		downstreams = append(downstreams, &downstream)
+	}
+
+	return downstreams, nil
+}
+
+// SetDownstreamVersionReady sets the status for the downstream version with the given sequence and app id to "pending"
+func SetDownstreamVersionReady(appID string, sequence int64) error {
+	db := persistence.MustGetPGSession()
+	query := `update app_downstream_version set status = 'pending' where app_id = $1 and sequence = $2`
+	_, err := db.Exec(query, appID, sequence)
+	if err != nil {
+		return errors.Wrap(err, "failed to set downstream version ready")
+	}
+
+	return nil
+}
+
+// SetDownstreamVersionPendingPreflight sets the status for the downstream version with the given sequence and app id to "pending_preflight"
+func SetDownstreamVersionPendingPreflight(appID string, sequence int64) error {
+	db := persistence.MustGetPGSession()
+	query := `update app_downstream_version set status = 'pending_preflight' where app_id = $1 and sequence = $2`
+	_, err := db.Exec(query, appID, sequence)
+	if err != nil {
+		return errors.Wrap(err, "failed to set downstream version pending preflight")
+	}
+
+	return nil
+}

--- a/pkg/downstream/types/types.go
+++ b/pkg/downstream/types/types.go
@@ -1,0 +1,6 @@
+package types
+
+type Downstream struct {
+	ClusterID string
+	Name      string
+}

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -1,4 +1,4 @@
-package app
+package gitops
 
 import (
 	"encoding/base64"
@@ -191,7 +191,7 @@ func gitOpsConfigFromSecretData(idx int64, secretData map[string][]byte) (string
 	return provider, publicKey, privateKey, repoURI, nil
 }
 
-func createGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName string, newSequence int, archiveDir string, downstreamName string) (string, error) {
+func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName string, newSequence int, archiveDir string, downstreamName string) (string, error) {
 	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load kots kinds")

--- a/pkg/handlers/airgap.go
+++ b/pkg/handlers/airgap.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kotsadm/pkg/app"
+	"github.com/replicatedhq/kotsadm/pkg/airgap"
 	"github.com/replicatedhq/kotsadm/pkg/logger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -32,7 +32,7 @@ func CreateAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pendingApp, err := app.GetPendingAirgapUploadApp()
+	pendingApp, err := airgap.GetPendingAirgapUploadApp()
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
@@ -65,7 +65,7 @@ func CreateAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 	}
 	go func() {
 		defer airgapBundle.Close()
-		if err := app.CreateAppFromAirgap(pendingApp, airgapBundle, registryHost, namespace, username, password); err != nil {
+		if err := airgap.CreateAppFromAirgap(pendingApp, airgapBundle, registryHost, namespace, username, password); err != nil {
 			logger.Error(err)
 		}
 	}()

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -79,22 +79,29 @@ func UpdateAppRegistry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// if hostname and namespace have not changed, we don't need to re-push
-	// if foundApp.RegistrySettings != nil {
-	// 	if foundApp.RegistrySettings.Hostname == updateAppRegistryRequest.Hostname {
-	// 		if foundApp.RegistrySettings.Namespace == updateAppRegistryRequest.Namespace {
+	registrySettings, err := registry.GetRegistrySettingsForApp(foundApp.ID)
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(500)
+		return
+	}
 
-	// 			err = app.UpdateRegistry(foundApp.ID, updateAppRegistryRequest.Hostname, updateAppRegistryRequest.Username, updateAppRegistryRequest.Password, updateAppRegistryRequest.Namespace)
-	// 			if err != nil {
-	// 				logger.Error(err)
-	// 				w.WriteHeader(500)
-	// 				return
-	// 			}
+	if registrySettings != nil {
+		if registrySettings.Hostname == updateAppRegistryRequest.Hostname {
+			if registrySettings.Namespace == updateAppRegistryRequest.Namespace {
 
-	// 			JSON(w, 200, updateAppRegistryResponse)
-	// 			return
-	// 		}
-	// 	}
-	// }
+				err = registry.UpdateRegistry(foundApp.ID, updateAppRegistryRequest.Hostname, updateAppRegistryRequest.Username, updateAppRegistryRequest.Password, updateAppRegistryRequest.Namespace)
+				if err != nil {
+					logger.Error(err)
+					w.WriteHeader(500)
+					return
+				}
+
+				JSON(w, 200, updateAppRegistryResponse)
+				return
+			}
+		}
+	}
 
 	// in a goroutine, start pushing the images to the remote registry
 	// we will let this function return while this happens

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -13,6 +13,9 @@ import (
 	"github.com/replicatedhq/kotsadm/pkg/license"
 	"github.com/replicatedhq/kotsadm/pkg/logger"
 	"github.com/replicatedhq/kotsadm/pkg/session"
+	"github.com/replicatedhq/kotsadm/pkg/task"
+	"github.com/replicatedhq/kotsadm/pkg/upstream"
+	"github.com/replicatedhq/kotsadm/pkg/version"
 )
 
 type AppUpdateCheckRequest struct {
@@ -51,7 +54,7 @@ func AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentStatus, err := app.GetTaskStatus("update-download")
+	currentStatus, err := task.GetTaskStatus("update-download")
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
@@ -68,7 +71,7 @@ func AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.ClearTaskStatus("update-download"); err != nil {
+	if err := task.ClearTaskStatus("update-download"); err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
 		return
@@ -83,7 +86,7 @@ func AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// download the app
-	archiveDir, err := app.GetAppVersionArchive(foundApp.ID, foundApp.CurrentSequence)
+	archiveDir, err := version.GetAppVersionArchive(foundApp.ID, foundApp.CurrentSequence)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
@@ -132,7 +135,7 @@ func AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 		defer os.RemoveAll(archiveDir)
 		for _, update := range updates {
 			// the latest version is in archive dir
-			if err := app.DownloadUpdate(foundApp, archiveDir, update.Cursor); err != nil {
+			if err := upstream.DownloadUpdate(foundApp.ID, archiveDir, update.Cursor); err != nil {
 				logger.Error(err)
 			}
 

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -289,3 +289,20 @@ func LoadConfigValuesFromFile(configValuesFilePath string) (*kotsv1beta1.ConfigV
 
 	return obj.(*kotsv1beta1.ConfigValues), nil
 }
+
+func LoadPreflightFromContents(content []byte) (*troubleshootv1beta1.Preflight, error) {
+	troubleshootscheme.AddToScheme(scheme.Scheme)
+
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+
+	obj, gvk, err := decode(content, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "not a preflight")
+	}
+
+	if gvk.String() != "troubleshoot.replicated.com/v1beta1, Kind=Preflight" {
+		return nil, errors.New("not a preflight")
+	}
+
+	return obj.(*troubleshootv1beta1.Preflight), nil
+}

--- a/pkg/kotsutil/yaml.go
+++ b/pkg/kotsutil/yaml.go
@@ -1,0 +1,25 @@
+package kotsutil
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/util"
+	yaml "github.com/replicatedhq/yaml/v3"
+)
+
+// FixUpYAML is a general purpose function that will ensure that YAML is copmatible with KOTS
+// This ensures that lines aren't wrapped at 80 chars which breaks template functions
+func FixUpYAML(inputContent []byte) ([]byte, error) {
+	yamlObj := map[string]interface{}{}
+
+	err := yaml.Unmarshal(inputContent, &yamlObj)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal yaml")
+	}
+
+	inputContent, err = util.MarshalIndent(2, yamlObj)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal yaml")
+	}
+
+	return inputContent, nil
+}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -12,6 +12,7 @@ import (
 	kotspull "github.com/replicatedhq/kots/pkg/pull"
 	"github.com/replicatedhq/kotsadm/pkg/app"
 	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
+	"github.com/replicatedhq/kotsadm/pkg/preflight"
 	"github.com/replicatedhq/kotsadm/pkg/registry"
 	"github.com/replicatedhq/kotsadm/pkg/render"
 	"github.com/replicatedhq/kotsadm/pkg/version"
@@ -79,18 +80,18 @@ func Sync(a *app.App, licenseData string) (*kotsv1beta1.License, error) {
 			return nil, errors.Wrap(err, "failed to render new version")
 		}
 
-		// newSequence, err := a.CreateVersion(archiveDir, "License Change")
-		// if err != nil {
-		// 	return nil, errors.Wrap(err, "failed to create new version")
-		// }
+		newSequence, err := version.CreateVersion(a.ID, archiveDir, "License Change", a.CurrentSequence)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create new version")
+		}
 
-		// if err := version.CreateAppVersionArchive(a.ID, newSequence, archiveDir); err != nil {
-		// 	return nil, errors.Wrap(err, "failed to upload")
-		// }
+		if err := version.CreateAppVersionArchive(a.ID, newSequence, archiveDir); err != nil {
+			return nil, errors.Wrap(err, "failed to upload")
+		}
 
-		// if err := preflight.Run(a.ID, newSequence, archiveDir); err != nil {
-		// 	return nil, errors.Wrap(err, "failed to run preflights")
-		// }
+		if err := preflight.Run(a.ID, newSequence, archiveDir); err != nil {
+			return nil, errors.Wrap(err, "failed to run preflights")
+		}
 	}
 
 	return latestLicense, nil

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -12,6 +12,7 @@ import (
 	kotspull "github.com/replicatedhq/kots/pkg/pull"
 	"github.com/replicatedhq/kotsadm/pkg/app"
 	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
+	"github.com/replicatedhq/kotsadm/pkg/preflight"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -78,6 +79,10 @@ func Sync(a *app.App, licenseData string) (*kotsv1beta1.License, error) {
 
 		if err := app.CreateAppVersionArchive(a.ID, newSequence, archiveDir); err != nil {
 			return nil, errors.Wrap(err, "failed to upload")
+		}
+
+		if err := preflight.Run(a.ID, newSequence, archiveDir); err != nil {
+			return nil, errors.Wrap(err, "failed to run preflights")
 		}
 	}
 

--- a/pkg/preflight/execute.go
+++ b/pkg/preflight/execute.go
@@ -1,0 +1,81 @@
+package preflight
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/logger"
+	"github.com/replicatedhq/kotsadm/pkg/persistence"
+	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
+	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
+	"go.uber.org/zap"
+	"k8s.io/client-go/rest"
+)
+
+// execute will execute the preflights using spec in renderedPreflights.
+// This spec should be rendered, no template functions remaining
+func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta1.Preflight) error {
+	logger.Debug("executing preflight checks",
+		zap.String("appID", appID),
+		zap.Int64("sequence", sequence))
+
+	progressChan := make(chan interface{}, 0) // non-zero buffer will result in missed messages
+
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to read in cluster config")
+	}
+
+	collectOpts := troubleshootpreflight.CollectOpts{
+		Namespace:              "",
+		IgnorePermissionErrors: false,
+		ProgressChan:           progressChan,
+		KubernetesRestConfig:   restConfig,
+	}
+
+	collectResults, err := troubleshootpreflight.Collect(collectOpts, preflightSpec)
+	if err != nil {
+		return errors.Wrap(err, "failed to collect")
+	}
+
+	analyzeResults := collectResults.Analyze()
+	if err != nil {
+		return errors.Wrap(err, "failed to analyze")
+	}
+
+	// the typescript api added some flair to this result
+	// so let's keep it for compatibility
+	// MORE TYPES!
+	uploadPreflightResults := &troubleshootpreflight.UploadPreflightResults{
+		Results: []*troubleshootpreflight.UploadPreflightResult{},
+	}
+	for _, analyzeResult := range analyzeResults {
+		uploadPreflightResult := &troubleshootpreflight.UploadPreflightResult{
+			IsFail:  analyzeResult.IsFail,
+			IsWarn:  analyzeResult.IsWarn,
+			IsPass:  analyzeResult.IsPass,
+			Title:   analyzeResult.Title,
+			Message: analyzeResult.Message,
+			URI:     analyzeResult.URI,
+		}
+
+		uploadPreflightResults.Results = append(uploadPreflightResults.Results, uploadPreflightResult)
+	}
+
+	b, err := json.Marshal(uploadPreflightResults)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal results")
+	}
+	db := persistence.MustGetPGSession()
+	query := `update app_downstream_version set preflight_result = $1, preflight_result_created_at = $2,
+status = (case when status = 'deployed' then 'deployed' else 'pending' end)
+where app_id = $3 and parent_sequence = $4`
+
+	_, err = db.Exec(query, b, time.Now(), appID, sequence)
+	if err != nil {
+		return errors.Wrap(err, "failed to write preflight results")
+	}
+
+	return nil
+}

--- a/pkg/preflight/execute.go
+++ b/pkg/preflight/execute.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// execute will execute the preflights using spec in renderedPreflights.
+// execute will execute the preflights using spec in preflightSpec.
 // This spec should be rendered, no template functions remaining
 func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta1.Preflight) error {
 	logger.Debug("executing preflight checks",

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -46,6 +46,7 @@ func Run(appID string, sequence int64, archiveDir string) error {
 		}
 
 		go func() {
+			logger.Debug("preflight checks beginning")
 			if err := execute(appID, sequence, p); err != nil {
 				logger.Error(err)
 				return

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -1,0 +1,56 @@
+package preflight
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/app"
+	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
+	"github.com/replicatedhq/kotsadm/pkg/logger"
+)
+
+func Run(appID string, sequence int64, archiveDir string) error {
+	renderedKotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to load rendered kots kinds")
+	}
+	if renderedKotsKinds.Preflight != nil {
+		// set the status to pending_preflights
+		if err := app.SetDownstreamVersionPendingPreflight(appID, int64(sequence)); err != nil {
+			return errors.Wrap(err, "failed to set downstream version pending preflight")
+		}
+
+		// render the preflight file
+		// we need to convert to bytes first, so that we can reuse the renderfile function
+		renderedMarshalledPreflights, err := renderedKotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Preflight")
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal rendered preflight")
+		}
+
+		a, err := app.Get(appID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get app")
+		}
+		renderedPreflight, err := a.RenderFile(renderedKotsKinds, []byte(renderedMarshalledPreflights))
+		if err != nil {
+			return errors.Wrap(err, "failed to render preflights")
+		}
+		p, err := kotsutil.LoadPreflightFromContents(renderedPreflight)
+		if err != nil {
+			return errors.Wrap(err, "failed to load rendered preflight")
+		}
+
+		go func() {
+			if err := execute(appID, sequence, p); err != nil {
+				logger.Error(err)
+				return
+			}
+
+			logger.Debug("preflight checks completed")
+		}()
+	} else {
+		if err := app.SetDownstreamVersionReady(appID, int64(sequence)); err != nil {
+			return errors.Wrap(err, "failed to set downstream version ready")
+		}
+	}
+
+	return nil
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,7 +1,8 @@
-package app
+package registry
 
 import (
 	"bufio"
+	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -13,17 +14,43 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/rewrite"
+	"github.com/replicatedhq/kotsadm/pkg/downstream"
 	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
+	"github.com/replicatedhq/kotsadm/pkg/app"
 	"github.com/replicatedhq/kotsadm/pkg/logger"
 	"github.com/replicatedhq/kotsadm/pkg/persistence"
+	"github.com/replicatedhq/kotsadm/pkg/registry/types"
+	"github.com/replicatedhq/kotsadm/pkg/task"
+	"github.com/replicatedhq/kotsadm/pkg/version"
 	"go.uber.org/zap"
 )
 
-type RegistrySettings struct {
-	Hostname    string
-	Username    string
-	PasswordEnc string
-	Namespace   string
+func GetRegistrySettingsForApp(appID string) (*types.RegistrySettings, error) {
+	db := persistence.MustGetPGSession()
+	query := `select registry_hostname, registry_username, registry_password_enc, namespace from app where id = $1`
+	row := db.QueryRow(query, appID)
+
+	var registryHostname sql.NullString
+	var registryUsername sql.NullString
+	var registryPasswordEnc sql.NullString
+	var registryNamespace sql.NullString
+
+	if err := row.Scan(&registryHostname, &registryUsername, &registryPasswordEnc, &registryNamespace); err != nil {
+		return nil, errors.Wrap(err, "failed to scan registry")
+	}
+
+	if !registryHostname.Valid {
+		return nil, nil
+	}
+
+	registrySettings := types.RegistrySettings{
+		Hostname:    registryHostname.String,
+		Username:    registryUsername.String,
+		PasswordEnc: registryPasswordEnc.String,
+		Namespace:   registryNamespace.String,
+	}
+
+	return &registrySettings, nil
 }
 
 func UpdateRegistry(appID string, hostname string, username string, password string, namespace string) error {
@@ -49,8 +76,8 @@ func UpdateRegistry(appID string, hostname string, username string, password str
 
 // RewriteImages will use the app (a) and send the images to the registry specified. It will create patches for these
 // and create a new version of the application
-func (a App) RewriteImages(hostname string, username string, password string, namespace string, configValues *kotsv1beta1.ConfigValues) error {
-	if err := SetTaskStatus("image-rewrite", "Updating registry settings", "running"); err != nil {
+func RewriteImages(appID string, sequence int64, hostname string, username string, password string, namespace string, configValues *kotsv1beta1.ConfigValues) error {
+	if err := task.SetTaskStatus("image-rewrite", "Updating registry settings", "running"); err != nil {
 		return errors.Wrap(err, "failed to set task status")
 	}
 
@@ -60,7 +87,7 @@ func (a App) RewriteImages(hostname string, username string, password string, na
 		for {
 			select {
 			case <-time.After(time.Second):
-				if err := UpdateTaskStatusTimestamp("image-rewrite"); err != nil {
+				if err := task.UpdateTaskStatusTimestamp("image-rewrite"); err != nil {
 					logger.Error(err)
 				}
 			case <-finishedCh:
@@ -72,18 +99,18 @@ func (a App) RewriteImages(hostname string, username string, password string, na
 	var finalError error
 	defer func() {
 		if finalError == nil {
-			if err := ClearTaskStatus("image-rewrite"); err != nil {
+			if err := task.ClearTaskStatus("image-rewrite"); err != nil {
 				logger.Error(err)
 			}
 		} else {
-			if err := SetTaskStatus("image-rewrite", finalError.Error(), "failed"); err != nil {
+			if err := task.SetTaskStatus("image-rewrite", finalError.Error(), "failed"); err != nil {
 				logger.Error(err)
 			}
 		}
 	}()
 
 	// get the archive and store it in a temporary location
-	appDir, err := GetAppVersionArchive(a.ID, a.CurrentSequence)
+	appDir, err := version.GetAppVersionArchive(appID, sequence)
 	if err != nil {
 		finalError = err
 		return errors.Wrap(err, "failed to get app version archive")
@@ -113,9 +140,19 @@ func (a App) RewriteImages(hostname string, username string, password string, na
 	}
 
 	// get the downstream names only
-	downstreams := []string{}
-	for _, downstream := range a.Downstreams {
-		downstreams = append(downstreams, downstream.Name)
+	downstreams, err := downstream.ListDownstreamsForApp(appID)
+	if err != nil {
+		return  errors.Wrap(err, "failed to list downstreams")
+	}
+
+	downstreamNames := []string{}
+	for _, d := range downstreams {
+		downstreamNames = append(downstreamNames, d.Name)
+	}
+
+	a, err := app.Get(appID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get app")
 	}
 
 	// dev_namespace makes the dev env work
@@ -131,7 +168,7 @@ func (a App) RewriteImages(hostname string, username string, password string, na
 	go func() {
 		scanner := bufio.NewScanner(pipeReader)
 		for scanner.Scan() {
-			if err := SetTaskStatus("image-rewrite", scanner.Text(), "running"); err != nil {
+			if err := task.SetTaskStatus("image-rewrite", scanner.Text(), "running"); err != nil {
 				logger.Error(err)
 			}
 		}
@@ -139,11 +176,11 @@ func (a App) RewriteImages(hostname string, username string, password string, na
 	}()
 
 	options := rewrite.RewriteOptions{
-		RootDir:           appDir,
-		UpstreamURI:       fmt.Sprintf("replicated://%s", license.Spec.AppSlug),
-		UpstreamPath:      filepath.Join(appDir, "upstream"),
-		Installation:      installation,
-		Downstreams:       downstreams,
+		RootDir:      appDir,
+		UpstreamURI:  fmt.Sprintf("replicated://%s", license.Spec.AppSlug),
+		UpstreamPath: filepath.Join(appDir, "upstream"),
+		Installation: installation,
+		Downstreams:       downstreamNames,
 		CreateAppDir:      false,
 		ExcludeKotsKinds:  true,
 		License:           license,
@@ -163,16 +200,16 @@ func (a App) RewriteImages(hostname string, username string, password string, na
 		return errors.Wrap(err, "failed to rewrite images")
 	}
 
-	newSequence, err := a.CreateVersion(appDir, "Registry Change")
-	if err != nil {
-		finalError = err
-		return errors.Wrap(err, "failed to create new version")
-	}
+	// newSequence, err := version.CreateVersion(appID, appDir, "Registry Change")
+	// if err != nil {
+	// 	finalError = err
+	// 	return errors.Wrap(err, "failed to create new version")
+	// }
 
-	if err := CreateAppVersionArchive(a.ID, newSequence, appDir); err != nil {
-		finalError = err
-		return errors.Wrap(err, "failed to upload app version")
-	}
+	// if err := version.CreateAppVersionArchive(a.ID, newSequence, appDir); err != nil {
+	// 	finalError = err
+	// 	return errors.Wrap(err, "failed to upload app version")
+	// }
 
 	return nil
 }

--- a/pkg/registry/types/types.go
+++ b/pkg/registry/types/types.go
@@ -1,0 +1,8 @@
+package types
+
+type RegistrySettings struct {
+	Hostname    string
+	Username    string
+	PasswordEnc string
+	Namespace   string
+}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -1,4 +1,4 @@
-package app
+package render
 
 import (
 	"encoding/base64"
@@ -11,12 +11,15 @@ import (
 	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/rewrite"
 	"github.com/replicatedhq/kots/pkg/template"
+	"github.com/replicatedhq/kotsadm/pkg/app"
+	"github.com/replicatedhq/kotsadm/pkg/downstream"
 	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
+	registrytypes "github.com/replicatedhq/kotsadm/pkg/registry/types"
 )
 
 // RenderFile renders a single file
 // this is useful for upstream/kotskinds files that are not rendered in the dir
-func (a *App) RenderFile(kotsKinds *kotsutil.KotsKinds, inputContent []byte) ([]byte, error) {
+func RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings *registrytypes.RegistrySettings, inputContent []byte) ([]byte, error) {
 	inputContent, err := kotsutil.FixUpYAML(inputContent)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fix up yaml")
@@ -29,8 +32,8 @@ func (a *App) RenderFile(kotsKinds *kotsutil.KotsKinds, inputContent []byte) ([]
 
 	localRegistry := template.LocalRegistry{}
 
-	if a.RegistrySettings != nil {
-		decodedPassword, err := base64.StdEncoding.DecodeString(a.RegistrySettings.PasswordEnc)
+	if registrySettings != nil {
+		decodedPassword, err := base64.StdEncoding.DecodeString(registrySettings.PasswordEnc)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to decode")
 		}
@@ -40,9 +43,9 @@ func (a *App) RenderFile(kotsKinds *kotsutil.KotsKinds, inputContent []byte) ([]
 			return nil, errors.Wrap(err, "failed to decrypt")
 		}
 
-		localRegistry.Host = a.RegistrySettings.Hostname
-		localRegistry.Namespace = a.RegistrySettings.Namespace
-		localRegistry.Username = a.RegistrySettings.Username
+		localRegistry.Host = registrySettings.Hostname
+		localRegistry.Namespace = registrySettings.Namespace
+		localRegistry.Username = registrySettings.Username
 		localRegistry.Password = string(decryptedPassword)
 	}
 
@@ -89,7 +92,7 @@ func (a *App) RenderFile(kotsKinds *kotsutil.KotsKinds, inputContent []byte) ([]
 
 // RenderDir renders an app archive dir
 // this is useful for when the license/config have updated, and template functions need to be evaluated again
-func (a *App) RenderDir(archiveDir string) error {
+func RenderDir(archiveDir string, appID string, registrySettings *registrytypes.RegistrySettings) error {
 	installation, err := kotsutil.LoadInstallationFromPath(filepath.Join(archiveDir, "upstream", "userdata", "installation.yaml"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load installation from path")
@@ -105,9 +108,15 @@ func (a *App) RenderDir(archiveDir string) error {
 		return errors.Wrap(err, "failed to load config values from path")
 	}
 
-	downstreams := []string{}
-	for _, downstream := range a.Downstreams {
-		downstreams = append(downstreams, downstream.Name)
+	// get the downstream names only
+	downstreams, err := downstream.ListDownstreamsForApp(appID)
+	if err != nil {
+		return errors.Wrap(err, "failed to list downstreams")
+	}
+
+	downstreamNames := []string{}
+	for _, d := range downstreams {
+		downstreamNames = append(downstreamNames, d.Name)
 	}
 
 	k8sNamespace := "default"
@@ -118,12 +127,17 @@ func (a *App) RenderDir(archiveDir string) error {
 		k8sNamespace = os.Getenv("POD_NAMESPACE")
 	}
 
+	a, err := app.Get(appID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get app")
+	}
+
 	reOptions := rewrite.RewriteOptions{
 		RootDir:          archiveDir,
 		UpstreamURI:      fmt.Sprintf("replicated://%s", license.Spec.AppSlug),
 		UpstreamPath:     filepath.Join(archiveDir, "upstream"),
 		Installation:     installation,
-		Downstreams:      downstreams,
+		Downstreams:      downstreamNames,
 		Silent:           true,
 		CreateAppDir:     false,
 		ExcludeKotsKinds: true,
@@ -134,13 +148,13 @@ func (a *App) RenderDir(archiveDir string) error {
 		IsAirgap:         a.IsAirgap,
 	}
 
-	if a.RegistrySettings != nil {
+	if registrySettings != nil {
 		cipher, err := crypto.AESCipherFromString(os.Getenv("API_ENCRYPTION_KEY"))
 		if err != nil {
 			return errors.Wrap(err, "failed to create aes cipher")
 		}
 
-		decodedPassword, err := base64.StdEncoding.DecodeString(a.RegistrySettings.PasswordEnc)
+		decodedPassword, err := base64.StdEncoding.DecodeString(registrySettings.PasswordEnc)
 		if err != nil {
 			return errors.Wrap(err, "failed to decode")
 		}
@@ -150,9 +164,9 @@ func (a *App) RenderDir(archiveDir string) error {
 			return errors.Wrap(err, "failed to decrypt")
 		}
 
-		reOptions.RegistryEndpoint = a.RegistrySettings.Hostname
-		reOptions.RegistryNamespace = a.RegistrySettings.Namespace
-		reOptions.RegistryUsername = a.RegistrySettings.Username
+		reOptions.RegistryEndpoint = registrySettings.Hostname
+		reOptions.RegistryNamespace = registrySettings.Namespace
+		reOptions.RegistryUsername = registrySettings.Username
 		reOptions.RegistryPassword = string(decryptedPassword)
 	}
 

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -1,4 +1,4 @@
-package app
+package task
 
 import (
 	"database/sql"

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -15,6 +15,7 @@ import (
 	"github.com/replicatedhq/kotsadm/pkg/app"
 	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
 	"github.com/replicatedhq/kotsadm/pkg/logger"
+	"github.com/replicatedhq/kotsadm/pkg/preflight"
 	"github.com/replicatedhq/kotsadm/pkg/registry"
 	"github.com/replicatedhq/kotsadm/pkg/task"
 	"github.com/replicatedhq/kotsadm/pkg/version"
@@ -146,6 +147,11 @@ func DownloadUpdate(appID string, archiveDir string, toCursor string) error {
 	if err := version.CreateAppVersionArchive(appID, newSequence, archiveDir); err != nil {
 		finalError = err
 		return errors.Wrap(err, "failed to create app version archive")
+	}
+
+	if err := preflight.Run(appID, newSequence, archiveDir); err != nil {
+		finalError = err
+		return errors.Wrap(err, "failed to run preflights")
 	}
 
 	return nil

--- a/pkg/version/archive.go
+++ b/pkg/version/archive.go
@@ -1,4 +1,4 @@
-package app
+package version
 
 import (
 	"fmt"

--- a/pkg/version/types/types.go
+++ b/pkg/version/types/types.go
@@ -1,0 +1,7 @@
+package types
+
+type AppVersion struct {
+	Sequence     int64
+	UpdateCursor int
+	VersionLabel string
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,276 @@
+package version
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/app"
+	"github.com/replicatedhq/kotsadm/pkg/config"
+	"github.com/replicatedhq/kotsadm/pkg/downstream"
+	"github.com/replicatedhq/kotsadm/pkg/gitops"
+	"github.com/replicatedhq/kotsadm/pkg/kotsutil"
+	"github.com/replicatedhq/kotsadm/pkg/persistence"
+	"github.com/replicatedhq/kotsadm/pkg/render"
+	"github.com/replicatedhq/kotsadm/pkg/version/types"
+)
+
+// CreateFirstVersion works much likst CreateVersion except that it assumes version 0
+// and never attempts to calculate a diff, or look at previous versions
+func CreateFirstVersion(appID string, filesInDir string, source string) (int64, error) {
+	return createVersion(appID, filesInDir, source, nil)
+}
+
+// CreateVersion creates a new version of the app in the database, but the caller
+// is responsible for uploading the archive to s3
+func CreateVersion(appID string, filesInDir string, source string, currentSequence int64) (int64, error) {
+	return createVersion(appID, filesInDir, source, &currentSequence)
+}
+
+// this is the common, internal function to create an app version, used in both
+// new and updates to apps
+func createVersion(appID string, filesInDir string, source string, currentSequence *int64) (int64, error) {
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filesInDir)
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to read kots kinds")
+	}
+
+	supportBundleSpec, err := kotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Collector")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal support bundle spec")
+	}
+	analyzersSpec, err := kotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Analyzer")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal analyzer spec")
+	}
+	preflightSpec, err := kotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Preflight")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal preflight spec")
+	}
+
+	appSpec, err := kotsKinds.Marshal("app.k8s.io", "v1beta1", "Application")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal app spec")
+	}
+	kotsAppSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Application")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal kots app spec")
+	}
+	backupSpec, err := kotsKinds.Marshal("velero.io", "v1", "Backup")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal backup spec")
+	}
+
+	licenseSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "License")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal license spec")
+	}
+	configSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Config")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal config spec")
+	}
+	configValuesSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "ConfigValues")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal configvalues spec")
+	}
+
+	// TODO: solve
+
+	// registrySettings, err := registry.GetRegistrySettingsForApp(appID)
+	// if err != nil {
+	// 	return int64(0), errors.Wrap(err, "failed to get registry settings")
+	// }
+
+	preflightBytes, err := render.RenderFile(kotsKinds, nil, []byte(preflightSpec))
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to template preflight spec")
+	}
+	templatedPreflight := string(preflightBytes)
+
+	db := persistence.MustGetPGSession()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to begin")
+	}
+	defer tx.Rollback()
+
+	newSequence := 0
+	if currentSequence != nil {
+		// determine next available sequence for this app - we shouldn't assume that a.CurrentSequence is accurate
+		row := tx.QueryRow(`select max(sequence) from app_version where app_id = $1`, appID)
+		err = row.Scan(&newSequence)
+		if err != nil {
+			return 0, errors.Wrap(err, "failed to find current max sequence in row")
+		}
+		newSequence++
+	}
+
+	query := `insert into app_version (app_id, sequence, created_at, version_label, release_notes, update_cursor, channel_name, encryption_key,
+supportbundle_spec, analyzer_spec, preflight_spec, app_spec, kots_app_spec, kots_license, config_spec, config_values, backup_spec)
+values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+ON CONFLICT(app_id, sequence) DO UPDATE SET
+created_at = EXCLUDED.created_at,
+version_label = EXCLUDED.version_label,
+release_notes = EXCLUDED.release_notes,
+update_cursor = EXCLUDED.update_cursor,
+channel_name = EXCLUDED.channel_name,
+encryption_key = EXCLUDED.encryption_key,
+supportbundle_spec = EXCLUDED.supportbundle_spec,
+analyzer_spec = EXCLUDED.analyzer_spec,
+preflight_spec = EXCLUDED.preflight_spec,
+app_spec = EXCLUDED.app_spec,
+kots_app_spec = EXCLUDED.kots_app_spec,
+kots_license = EXCLUDED.kots_license,
+config_spec = EXCLUDED.config_spec,
+config_values = EXCLUDED.config_values,
+backup_spec = EXCLUDED.backup_spec`
+	_, err = tx.Exec(query, appID, newSequence, time.Now(),
+		kotsKinds.Installation.Spec.VersionLabel,
+		kotsKinds.Installation.Spec.ReleaseNotes,
+		kotsKinds.Installation.Spec.UpdateCursor,
+		kotsKinds.Installation.Spec.ChannelName,
+		kotsKinds.Installation.Spec.EncryptionKey,
+		supportBundleSpec,
+		analyzersSpec,
+		templatedPreflight,
+		appSpec,
+		kotsAppSpec,
+		licenseSpec,
+		configSpec,
+		configValuesSpec,
+		backupSpec)
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to insert app version")
+	}
+
+	appName := kotsKinds.KotsApplication.Spec.Title
+	if appName == "" {
+		a, err := app.Get(appID)
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to get app")
+		}
+
+		appName = a.Name
+	}
+
+	appIcon := kotsKinds.KotsApplication.Spec.Icon
+
+	query = "update app set current_sequence = $1, name = $2, icon_uri = $3 where id = $4"
+	_, err = tx.Exec(query, int64(newSequence), appName, appIcon, appID)
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to update app")
+	}
+
+	previousArchiveDir := ""
+	if currentSequence != nil {
+		// Get the previous archive, we need this to calculate the diff
+		previousDir, err := GetAppVersionArchive(appID, *currentSequence)
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to get previous archive")
+		}
+
+		previousArchiveDir = previousDir
+	}
+
+	downstreams, err := downstream.ListDownstreamsForApp(appID)
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to list downstreams")
+	}
+
+	for _, d := range downstreams {
+		downstreamStatus := "pending"
+		if currentSequence == nil && kotsKinds.Config != nil {
+			downstreamStatus = "pending_config"
+		} else if kotsKinds.Preflight != nil {
+			downstreamStatus = "pending_preflight"
+		}
+
+		diffSummary := ""
+		if currentSequence != nil {
+			// diff this release from the last release
+			diff, err := downstream.DiffAppVersionsForDownstreams(d.Name, filesInDir, previousArchiveDir)
+			if err != nil {
+				return int64(0), errors.Wrap(err, "failed to diff")
+			}
+			b, err := json.Marshal(diff)
+			if err != nil {
+				return int64(0), errors.Wrap(err, "failed to marshal diff")
+			}
+			diffSummary = string(b)
+
+			// check if version needs additional configuration
+			t, err := config.NeedsConfiguration(configSpec, configValuesSpec, licenseSpec)
+			if err != nil {
+				return int64(0), errors.Wrap(err, "failed to check if version needs configuration")
+			}
+			if t {
+				downstreamStatus = "pending_config"
+			}
+		}
+
+		commitURL := ""
+		query = `select max(sequence) from app_downstream_version where app_id = $1 and cluster_id = $2`
+		row := tx.QueryRow(query, appID, d.ClusterID)
+
+		lastDownstreamSequence := int64(-1)
+		if err := row.Scan(&lastDownstreamSequence); err != nil {
+			// continue, it's 0
+		}
+		newSequence := lastDownstreamSequence + 1
+
+		downstreamGitOps, err := gitops.GetDownstreamGitOps(appID, d.ClusterID)
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to get downstream gitops")
+		}
+		if downstreamGitOps != nil {
+			a, err := app.Get(appID)
+			if err != nil {
+				return int64(0), errors.Wrap(err, "failed to get app")
+			}
+			createdCommitURL, err := gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, int(newSequence), filesInDir, d.Name)
+			if err != nil {
+				return int64(0), errors.Wrap(err, "failed to create gitops commit")
+			}
+
+			commitURL = createdCommitURL
+		}
+
+		query = `insert into app_downstream_version (app_id, cluster_id, sequence, parent_sequence, created_at, version_label, status, source, diff_summary, git_commit_url, git_deployable) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
+		_, err = tx.Exec(query, appID, d.ClusterID, newSequence, newSequence, time.Now(),
+			kotsKinds.Installation.Spec.VersionLabel, downstreamStatus, source,
+			diffSummary, commitURL, commitURL != "")
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to create downstream version")
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return int64(0), errors.Wrap(err, "failed to commit")
+	}
+
+	return int64(newSequence), nil
+}
+
+// return the list of versions available for an app
+func GetVersions(appID string) ([]types.AppVersion, error) {
+	db := persistence.MustGetPGSession()
+	query := `select sequence, update_cursor, version_label from app_version where app_id = $1 order by update_cursor asc, sequence asc`
+	rows, err := db.Query(query, appID)
+	if err != nil {
+		return nil, errors.Wrap(err, "query app_version table")
+	}
+
+	versions := []types.AppVersion{}
+
+	for rows.Next() {
+		rowVersion := types.AppVersion{}
+		err = rows.Scan(&rowVersion.Sequence, &rowVersion.UpdateCursor, &rowVersion.VersionLabel)
+		if err != nil {
+			return nil, errors.Wrap(err, "scan row from app_version table")
+		}
+		versions = append(versions, rowVersion)
+	}
+
+	return versions, nil
+}


### PR DESCRIPTION
Removing the deploysocket to run preflights and just using the kotsadm vendor'ed version of preflight.


This introduces a regression that must be solved before we can release the next version: `kots upload` will not trigger preflights because it's uploading to the TS API. That's code that needs to change in KOTS, so I'll move there next.