### PR TITLE
return if file does not exist

### DIFF
--- a/api/src/kots_app/kots_app.ts
+++ b/api/src/kots_app/kots_app.ts
@@ -391,6 +391,7 @@ export class KotsApp {
         const secretFile = path.join(tmpDir.name, "overlays", "midstream", "secret.yaml")
         if (!fs.existsSync(secretFile)) {
           resolve("");
+          return;
         }
 
         const content = fs.readFileSync(secretFile, "utf-8");


### PR DESCRIPTION
kotsadm-api is in CrashLoopBackOff
```
Error: ENOENT: no such file or directory, open '/tmp/tmp-167CFXdrOjy40/overlays/midstream/secret.yaml'
    at Object.openSync (fs.js:443:3)
    at Object.readFileSync (fs.js:343:35)
    at Extract.extract.on (/src/src/kots_app/kots_app.ts:396:28)
    at Extract.emit (events.js:203:15)
    at Extract.EventEmitter.emit (domain.js:448:20)
    at finishMaybe (/src/node_modules/tar-stream/node_modules/readable-stream/lib/_stream_writable.js:607:14)
    at /src/node_modules/tar-stream/node_modules/readable-stream/lib/_stream_writable.js:585:5
    at Extract._final (/src/node_modules/tar-stream/extract.js:255:3)
    at callFinal (/src/node_modules/tar-stream/node_modules/readable-stream/lib/_stream_writable.js:578:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```