### PR TITLE
allowSnapshots from app version Backup

### DIFF
--- a/api/src/kots_app/kots_app.ts
+++ b/api/src/kots_app/kots_app.ts
@@ -485,13 +485,12 @@ export class KotsApp {
     if (!partOfLicenseYaml) {
       return false;
     }
-
-    const currentAppVersion = await stores.kotsAppStore.getCurrentAppVersion(this.id);
-    if (!currentAppVersion || !currentAppVersion.backupSpec) {
-      return false
+    const tmpl = await stores.kotsAppStore.getDeployedVersionBackup(this.id);
+    if (!tmpl) {
+      return false;
     }
     const registryInfo = await stores.kotsAppStore.getAppRegistryDetails(this.id);
-    const rendered = await kotsRenderFile(this, stores, currentAppVersion.backupSpec, registryInfo);
+    const rendered = await kotsRenderFile(this, stores, tmpl, registryInfo);
     const backup = yaml.safeLoad(rendered);
     const annotations = _.get(backup, "metadata.annotations") as any;
     if (!_.isPlainObject(annotations)) {

--- a/api/src/kots_app/kots_app.ts
+++ b/api/src/kots_app/kots_app.ts
@@ -480,12 +480,16 @@ export class KotsApp {
     return false;
   }
 
-  private async isAllowSnapshots(stores: Stores): Promise<boolean> {
+  private async isAllowSnapshots(stores: Stores, downstreams: Cluster[]): Promise<boolean> {
     const partOfLicenseYaml = await stores.kotsAppStore.isAllowSnapshotsPartOfLicenseYaml(this.id, this.currentSequence!);
     if (!partOfLicenseYaml) {
       return false;
     }
-    const tmpl = await stores.kotsAppStore.getDeployedVersionBackup(this.id);
+    if (!downstreams.length) {
+      return false;
+    }
+    const clusterID = downstreams[0].id;
+    const tmpl = await stores.kotsAppStore.getDeployedVersionBackup(this.id, clusterID);
     if (!tmpl) {
       return false;
     }
@@ -542,7 +546,7 @@ export class KotsApp {
       ...this,
       isGitOpsSupported: () => this.isGitOpsSupported(stores),
       allowRollback: () => this.isAllowRollback(stores),
-      allowSnapshots: () => this.isAllowSnapshots(stores),
+      allowSnapshots: () => this.isAllowSnapshots(stores, downstreams),
       currentVersion: () => this.getCurrentAppVersion(stores),
       licenseType: () => this.getKotsLicenseType(stores),
       downstreams: _.map(downstreams, (downstream) => {

--- a/api/src/kots_app/kots_app_store.ts
+++ b/api/src/kots_app/kots_app_store.ts
@@ -954,7 +954,7 @@ order by adv.sequence desc`;
       return;
     }
 
-    q = `select created_at, version_label, release_notes, status, sequence, applied_at from app_version where app_id = $1 and sequence = $2`;
+    q = `select created_at, version_label, release_notes, status, sequence, applied_at, backup_spec from app_version where app_id = $1 and sequence = $2`;
     v = [
       appId,
       sequence,
@@ -979,6 +979,7 @@ order by adv.sequence desc`;
       deployedAt: row.applied_at,
       preflightResult: row.preflight_result,
       preflightResultCreatedAt: row.preflight_result_created_at,
+      backupSpec: row.backup_spec,
     };
 
     return versionItem;

--- a/api/src/kots_app/kots_app_store.ts
+++ b/api/src/kots_app/kots_app_store.ts
@@ -880,16 +880,17 @@ order by sequence desc`;
     }
   }
 
-  async getDeployedVersionBackup(appId: string): Promise<string|void> {
-    let q = `select app_version.backup_spec from app_version
+  async getDeployedVersionBackup(appId: string, clusterId: string): Promise<string|void> {
+    const q = `select app_version.backup_spec from app_version
       inner join app_downstream on
         app_version.sequence = app_downstream.current_sequence AND
         app_version.app_id = app_downstream.app_id
-      where app_version.app_id = $1`;
-    let v = [
+      where app_downstream.app_id = $1 and app_downstream.cluster_id = $2`;
+    const v = [
       appId,
+      clusterId,
     ];
-    let result = await this.pool.query(q, v);
+    const result = await this.pool.query(q, v);
     if (result.rows.length === 0) {
       return;
     }

--- a/api/src/kots_app/kots_app_store.ts
+++ b/api/src/kots_app/kots_app_store.ts
@@ -880,6 +880,22 @@ order by sequence desc`;
     }
   }
 
+  async getDeployedVersionBackup(appId: string): Promise<string|void> {
+    let q = `select app_version.backup_spec from app_version
+      inner join app_downstream on
+        app_version.sequence = app_downstream.current_sequence AND
+        app_version.app_id = app_downstream.app_id
+      where app_version.app_id = $1`;
+    let v = [
+      appId,
+    ];
+    let result = await this.pool.query(q, v);
+    if (result.rows.length === 0) {
+      return;
+    }
+    return result.rows[0].backup_spec;
+  }
+
   async getCurrentVersion(appId: string, clusterId: string): Promise<KotsVersion | undefined> {
     let q = `select current_sequence from app_downstream where app_id = $1 and cluster_id = $2`;
     let v = [


### PR DESCRIPTION
Existence of a Backup in an app version enables snapshots unless
overridden by license or by kots.io/exclude or kots.io/when annotations
in the Backup itself.