### PR TITLE
Updated for web to run on 30000

### DIFF
--- a/api/kustomize/overlays/dev/deployment.yaml
+++ b/api/kustomize/overlays/dev/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - name: SHIP_API_ENDPOINT
               value: http://kotsadm-api.default.svc.cluster.local:3000
             - name: SHIP_API_ADVERTISE_ENDPOINT
-              value: http://localhost:30065
+              value: http://127.0.0.1:30065
             - name: GRAPHQL_PREM_ENDPOINT
               value: http://graphql-api-prem:3000/graphql
             - name: AUTO_CREATE_CLUSTER

--- a/go.mod
+++ b/go.mod
@@ -3,29 +3,16 @@ module github.com/replicatedhq/kotsadm
 go 1.12
 
 require (
-	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
-	github.com/Microsoft/hcsshim v0.8.8-0.20200225064221-b400e4ffeccc // indirect
-	github.com/VividCortex/ewma v1.1.1 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aws/aws-sdk-go v1.25.18
-	github.com/chzyer/logex v1.1.11-0.20160617073814-96a4d311aa9b // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/docker/docker v1.13.1 // indirect
-	github.com/docker/docker-credential-helpers v0.6.3 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
-	github.com/etcd-io/bbolt v1.3.3 // indirect
 	github.com/frankban/quicktest v1.7.3 // indirect
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.0
-	github.com/huandu/xstrings v1.2.1 // indirect
-	github.com/klauspost/cpuid v1.2.1 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kubernetes-sigs/application v0.8.1 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/mholt/archiver v3.1.1+incompatible
-	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kots v1.13.6
 	github.com/replicatedhq/troubleshoot v0.9.26
@@ -36,14 +23,11 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.5.1
-	github.com/vbauerster/mpb v3.4.0+incompatible // indirect
 	github.com/vmware-tanzu/velero v1.2.0
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xeipuuv/gojsonschema v1.1.0 // indirect
 	go.uber.org/multierr v1.5.0 // indirect
 	go.uber.org/zap v1.13.0
+	go.undefinedlabs.com/scopeagent v0.1.12
 	golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
-	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	k8s.io/api v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -922,6 +923,8 @@ go.uber.org/zap v1.13.0 h1:nR6NoDBgAf67s68NhaXbsojM+2gxp3S1hWkHDl27pVU=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.undefinedlabs.com/scopeagent v0.1.7 h1:TPALQQNkPah8NgVjPKKhaBNZL2hg+hY2GRPfRMSt48c=
 go.undefinedlabs.com/scopeagent v0.1.7/go.mod h1:XCD8wnuBZ+eskhynYNP+uvBiFan9cFrWLwHnWOETXDU=
+go.undefinedlabs.com/scopeagent v0.1.12 h1:EKOFhKGIWlEaNOziVMU3Fs5vMo9BdEMLUOx6EXvOuUQ=
+go.undefinedlabs.com/scopeagent v0.1.12/go.mod h1:phe27toysIN8sk8tq6T99zi3WLVVwSASUAQb0ENVm9E=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d/go.mod h1:OWs+y06UdEOHN4y+MfF/py+xQ/tYqIWW03b70/CG9Rw=
 golang.org/x/build v0.0.0-20190927031335-2835ba2e683f/go.mod h1:fYw7AShPAhGMdXqA9gRadk/CcMsvLlClpE5oBwnS3dM=
@@ -1137,6 +1140,7 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c/go.mod h1:3HH7i1SgMqlzxCcBmUHW657sD4Kvv9sC3HpL3YukzwA=

--- a/web/Dockerfile.skaffold
+++ b/web/Dockerfile.skaffold
@@ -9,7 +9,7 @@ RUN yarn install --silent --frozen-lockfile
 ADD . /src/
 WORKDIR /src
 
-EXPOSE 8000
+EXPOSE 30000
 RUN make deps
 
 ENTRYPOINT ["make", "serve"]

--- a/web/env/skaffold.js
+++ b/web/env/skaffold.js
@@ -1,8 +1,8 @@
 module.exports = {
   ENVIRONMENT: "development",
   SECURE_ADMIN_CONSOLE: true,
-  API_ENDPOINT: "http://localhost:30065/api/v1",
-  GRAPHQL_ENDPOINT: "http://localhost:30065/graphql",
+  API_ENDPOINT: "http://127.0.0.1:30065/api/v1",
+  GRAPHQL_ENDPOINT: "http://127.0.0.1:30065/graphql",
   SHIP_CLUSTER_BUILD_VERSION: (function () {
     return String(Date.now());
   }()),

--- a/web/kustomize/overlays/dev/deployment.yaml
+++ b/web/kustomize/overlays/dev/deployment.yaml
@@ -14,4 +14,4 @@ spec:
             - name: SHIP_CLUSTER_API_SERVER
               value: "http://127.0.0.1:30065"
             - name: SHIP_CLUSTER_WEB_URI
-              value: "http://localhost:30000"
+              value: "http://127.0.0.1:30000"

--- a/web/kustomize/overlays/dev/deployment.yaml
+++ b/web/kustomize/overlays/dev/deployment.yaml
@@ -9,9 +9,9 @@ spec:
         - name: kotsadm-web
           ports:
             - name: http
-              containerPort: 8000
+              containerPort: 30000
           env:
             - name: SHIP_CLUSTER_API_SERVER
-              value: "http://localhost:30065"
+              value: "http://127.0.0.1:30065"
             - name: SHIP_CLUSTER_WEB_URI
-              value: "http://localhost:8000"
+              value: "http://localhost:30000"

--- a/web/kustomize/overlays/dev/nodeport.yaml
+++ b/web/kustomize/overlays/dev/nodeport.yaml
@@ -8,7 +8,7 @@ spec:
   type: NodePort
   ports:
   - name: http
-    port: 8000
+    port: 30000
     targetPort: http
     nodePort: 30000
   selector:

--- a/web/webpack.config.dev.js
+++ b/web/webpack.config.dev.js
@@ -43,7 +43,7 @@ module.exports = {
   devtool: "eval-source-map",
 
   devServer: {
-    port: 8000,
+    port: 30000,
     host: "0.0.0.0",
     hot: true,
     hotOnly: true,


### PR DESCRIPTION
This changes the local dev environment to remove the mapping from 8000 -> 30000 that was only used for the web ui. Having this port mapping made it difficult to run outside of our specific environment.

This also changes from localhost -> 127.0.0.1 to force ipv4 internally for now. 