### PR TITLE
Download in the Go api

### DIFF
--- a/api/src/controllers/kots/KotsAPI.ts
+++ b/api/src/controllers/kots/KotsAPI.ts
@@ -109,6 +109,8 @@ export class KotsAPI {
     }
   }
 
+  // Downloading apps was moved to the Go API in 1.14.0
+  // this function is deprecated and will be removed in 1.16.0
   @Get("/:slug")
   async kotsDownload(
     @Req() request: Request,

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -48,6 +48,7 @@ func Start() {
 
 	// Implemented handlers
 	r.Path("/api/v1/upload").Methods("PUT").HandlerFunc(handlers.UploadExistingApp)
+	r.Path("/api/v1/download").Methods("GET").HandlerFunc(handlers.DownloadApp)
 	r.HandleFunc("/api/v1/login", handlers.Login)
 	r.HandleFunc("/api/v1/logout", handlers.NotImplemented)
 	r.Path("/api/v1/metadata").Methods("OPTIONS", "GET").HandlerFunc(handlers.Metadata)


### PR DESCRIPTION
This adds the Go API for 1.14.0 downloads.

It adds a comment to remove the TS API in 1.16.0.
