### PR TITLE
create a backupstoragelocation for every app slug

### DIFF
--- a/api/src/kots_app/kots_app_store.ts
+++ b/api/src/kots_app/kots_app_store.ts
@@ -419,6 +419,14 @@ export class KotsAppStore {
     return apps;
   }
 
+  async listAppSlugs(): Promise<string[]> {
+    const q = `select slug from app`;
+    const v = [];
+
+    const result = await this.pool.query(q,v);
+    return _.map(result.rows, ({ slug }) => slug);
+  }
+
   async updateDownstreamsStatus(appId: string, sequence: number, status: string, statusInfo: string): Promise<void> {
     const q = `
       update app_downstream_version

--- a/api/src/kots_app/resolvers/kots_app_mutations.ts
+++ b/api/src/kots_app/resolvers/kots_app_mutations.ts
@@ -21,6 +21,7 @@ import { Params } from "../../server/params";
 import { Repeater } from "../../util/repeater";
 import { sendInitialGitCommitsForAppDownstream } from "../gitops";
 import { StatusServer } from "../../airgap/status";
+import { logger } from "../../server/logger";
 
 // tslint:disable-next-line max-func-body-length cyclomatic-complexity
 export function KotsMutations(stores: Stores) {
@@ -98,7 +99,7 @@ export function KotsMutations(stores: Stores) {
 
         return true;
       } catch (err) {
-        console.log(err);
+        logger.error(err);
         const gitOpsError = err.errno ? `Error code ${err.errno}` : "Unknown error connecting to repo";
         await stores.kotsAppStore.setGitOpsError(appId, clusterId, gitOpsError);
         return false;
@@ -245,7 +246,7 @@ export function KotsMutations(stores: Stores) {
 }
 
 // tslint:disable-next-line cyclomatic-complexity
-async function createKotsApp(stores: Stores, kotsApp: KotsApp, downstreamName: string): Promise<{ hasPreflight: boolean, isConfigurable: boolean }> {
+async function createKotsApp(stores: Stores, kotsApp: KotsApp, downstreamName: string): Promise<{ hasPreflight: boolean; isConfigurable: boolean }> {
   const liveness = new Repeater(() => {
     return new Promise((resolve) => {
       stores.kotsAppStore.updateOnlineInstallLiveness().finally(() => {

--- a/api/src/snapshots/resolvers/snapshot_mutations.ts
+++ b/api/src/snapshots/resolvers/snapshot_mutations.ts
@@ -76,9 +76,15 @@ export function SnapshotMutations(stores: Stores) {
           accessKeySecret,
         },
       };
+      const slugs = await stores.kotsAppStore.listAppSlugs();
       const client = new VeleroClient("velero"); // TODO velero namespace
 
-      return client.saveSnapshotStore(config);
+      try {
+        await client.saveSnapshotStore(config, slugs);
+      } catch(e) {
+        logger.error(e);
+        throw e;
+      }
     },
 
     async snapshotProviderS3Compatible(root: any, args: any, context: Context): Promise<void> {
@@ -96,9 +102,10 @@ export function SnapshotMutations(stores: Stores) {
           accessKeySecret,
         },
       };
+      const slugs = await stores.kotsAppStore.listAppSlugs();
       const client = new VeleroClient("velero"); // TODO velero namespace
 
-      return client.saveSnapshotStore(config);
+      return client.saveSnapshotStore(config, slugs);
     },
 
     async snapshotProviderAzure(root: any, args: any, context: Context): Promise<void> {
@@ -119,9 +126,10 @@ export function SnapshotMutations(stores: Stores) {
           cloudName,
         },
       };
+      const slugs = await stores.kotsAppStore.listAppSlugs();
       const client = new VeleroClient("velero"); // TODO velero namespace
 
-      return client.saveSnapshotStore(config);
+      return client.saveSnapshotStore(config, slugs);
     },
 
     async snapshotProviderGoogle(root: any, args: any, context: Context): Promise<void> {
@@ -136,9 +144,10 @@ export function SnapshotMutations(stores: Stores) {
           serviceAccount,
         },
       };
+      const slugs = await stores.kotsAppStore.listAppSlugs();
       const client = new VeleroClient("velero"); // TODO velero namespace
 
-      return client.saveSnapshotStore(config);
+      return client.saveSnapshotStore(config, slugs);
     },
 
     async manualSnapshot(root: any, args: any, context: Context): Promise<void> {

--- a/api/src/snapshots/resolvers/snapshot_queries.ts
+++ b/api/src/snapshots/resolvers/snapshot_queries.ts
@@ -11,6 +11,7 @@ import { Phase } from "../velero";
 import { SnapshotConfig, SnapshotSettings } from "../snapshot_config";
 import { VeleroClient } from "./veleroClient";
 import { parseTTL } from "../backup";
+import { logger } from "../../server/logger";
 
 export function SnapshotQueries(stores: Stores, params: Params) {
   // tslint:disable-next-line max-func-body-length
@@ -19,10 +20,10 @@ export function SnapshotQueries(stores: Stores, params: Params) {
       context.requireSingleTenantSession();
       
       const velero = new VeleroClient("velero");
-      return await velero.isVeleroInstalled();
+      return velero.isVeleroInstalled();
     },
 
-    async snapshotConfig(root: any, args: any, context: Context): Promise<SnapshotConfig> {
+    async snapshotConfig(root: any, args: any, context: Context): Promise<SnapshotConfig|undefined> {
       context.requireSingleTenantSession();
 
       const appId = await stores.kotsAppStore.getIdFromSlug(args.slug);
@@ -39,7 +40,7 @@ export function SnapshotQueries(stores: Stores, params: Params) {
           inputValue: quantity.toString(),
           inputTimeUnit: unit,
           converted: app.snapshotTTL,
-        };
+        }
       }
 
       return {
@@ -64,11 +65,10 @@ export function SnapshotQueries(stores: Stores, params: Params) {
       context.requireSingleTenantSession();
 
       const { slug } = args;
-      const client = new VeleroClient("velero"); // TODO namespace
-      const snapshots = await client.listSnapshots();
+      const velero = new VeleroClient("velero"); // TODO namespace
+      await velero.maybeCreateAppBackend(slug);
 
-      // TODO filter earlier
-      return _.filter(snapshots, { appSlug: slug });
+      return velero.listSnapshots(slug);
     },
 
     async snapshotDetail(root: any, args: any, context: Context): Promise<SnapshotDetail> {

--- a/api/src/snapshots/resolvers/snapshot_queries.ts
+++ b/api/src/snapshots/resolvers/snapshot_queries.ts
@@ -23,7 +23,7 @@ export function SnapshotQueries(stores: Stores, params: Params) {
       return velero.isVeleroInstalled();
     },
 
-    async snapshotConfig(root: any, args: any, context: Context): Promise<SnapshotConfig|undefined> {
+    async snapshotConfig(root: any, args: any, context: Context): Promise<SnapshotConfig> {
       context.requireSingleTenantSession();
 
       const appId = await stores.kotsAppStore.getIdFromSlug(args.slug);

--- a/api/src/snapshots/snapshot_config.ts
+++ b/api/src/snapshots/snapshot_config.ts
@@ -58,8 +58,8 @@ export interface SnapshotStoreGoogle {
 
 export interface SnapshotStore {
   provider: SnapshotProvider;
-  bucket: String;
-  path?: String;
+  bucket: string;
+  path?: string;
   s3AWS?: SnapshotStoreS3AWS;
   s3Compatible?: SnapshotStoreS3Compatible;
   azure?: SnapshotStoreAzure;

--- a/web/src/components/apps/AppSnapshotSettings.jsx
+++ b/web/src/components/apps/AppSnapshotSettings.jsx
@@ -88,7 +88,7 @@ class AppSnapshotSettings extends Component {
     const { store } = snapshotSettings.snapshotSettings;
 
     if (store?.s3AWS) {
-      const useIam = !!store.s3AWS.accessKeyID.length || !!store.s3AWS.accessKeySecret.length;
+      const useIam = !!store.s3AWS.accessKeyID?.length || !!store.s3AWS.accessKeySecret?.length;
       return this.setState({
         determiningDestination: false,
         selectedDestination: find(DESTINATIONS, ["value", "aws"]),
@@ -194,8 +194,8 @@ class AppSnapshotSettings extends Component {
       this.state.s3bucket,
       this.state.s3Path,
       this.state.s3Region,
-      this.state.useIam && this.state.s3KeyId,
-      this.state.useIam && this.state.s3KeySecret,
+      this.state.useIam ? this.state.s3KeyId : "",
+      this.state.useIam ? this.state.s3KeySecret : "",
     ).then(() => {
       this.setState({ updatingSettings: false });
     })


### PR DESCRIPTION
The kotsadm-velero-backend BackupStorageLocation acts as a template for each app's BackupStorageLocation, which is identical except for the name and path prefix in the bucket. The app slug is appended to the prefix specified by the user.

Add a label to each Backup so that listing snapshots can filter in the Kubernetes API instead of on the client.

Ensure that a BackupStorageLocation exists for the app at three points:
1. When the snapshot store config is saved
2. When snapshots for the app are listed
3. When a snapshot for the app is started

Gracefully handle 404s when looking up existing credential secrets with corev1 client.