### PR TITLE
Download snapshot logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/frankban/quicktest v1.7.3 // indirect
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
-	github.com/google/martian v2.1.0+incompatible
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.0
 	github.com/klauspost/cpuid v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,24 @@ module github.com/replicatedhq/kotsadm
 go 1.12
 
 require (
-	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Microsoft/hcsshim v0.8.8-0.20200225064221-b400e4ffeccc // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aws/aws-sdk-go v1.25.18
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/docker/docker v1.13.1 // indirect
 	github.com/frankban/quicktest v1.7.3 // indirect
-	github.com/go-logr/zapr v0.1.1 // indirect
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
+	github.com/google/martian v2.1.0+incompatible
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.0
-	github.com/huandu/xstrings v1.3.0 // indirect
+	github.com/klauspost/cpuid v1.2.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kubernetes-sigs/application v0.8.1 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kots v1.13.10-0.20200317153303-89d5bfaddd77
+	github.com/replicatedhq/kotsadm/operator v0.0.0-20200319203633-86dcbbd1ab78 // indirect
 	github.com/replicatedhq/troubleshoot v0.9.27-0.20200310173216-983aaaacea80
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/segmentio/ksuid v1.0.2
@@ -26,6 +30,8 @@ require (
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.5.1
 	github.com/vmware-tanzu/velero v1.2.0
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonschema v1.1.0 // indirect
 	go.uber.org/multierr v1.5.0 // indirect
 	go.uber.org/zap v1.13.0
 	go.undefinedlabs.com/scopeagent v0.1.12

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,7 @@ github.com/containers/storage v1.16.2/go.mod h1:/RNmsK01ajCL+VtMSi3W8kHzpBwN+Q5g
 github.com/coredns/corefile-migration v1.0.4/go.mod h1:OFwBp/Wc9dJt5cAZzHWMNhK1r5L0p0jDwIBc6j8NC8E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.15+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -469,6 +470,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -609,6 +611,7 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -694,6 +697,7 @@ github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/pact-foundation/pact-go v1.0.0-beta.5/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -746,9 +750,12 @@ github.com/replicatedhq/kots v1.13.3 h1:AnraOU2iAqfkkLRD6wujX30Sr+OG37lPqldZRRKF
 github.com/replicatedhq/kots v1.13.3/go.mod h1:wI3W7ksjw8IupLA3m4gGJ79fWZIhSJfU/SaPZqm9pVA=
 github.com/replicatedhq/kots v1.13.10-0.20200317153303-89d5bfaddd77 h1:WyWMDo/B+V+lT287arLEQfNZcQon6WfxPsudC9Co3w8=
 github.com/replicatedhq/kots v1.13.10-0.20200317153303-89d5bfaddd77/go.mod h1:fKQZXHH3VyZcKzQPpy3MNA5rBkiiK9feb5TFBKu2qpA=
+github.com/replicatedhq/kotsadm/operator v0.0.0-20200319203633-86dcbbd1ab78 h1:ea4KHKGAz93Jh9vENjRm5MThOoxAaoInawlYABhd50E=
+github.com/replicatedhq/kotsadm/operator v0.0.0-20200319203633-86dcbbd1ab78/go.mod h1:NSqt331XhUNgvyb3/THH6lCnpB1NNM+7eGWWM4acW3U=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56 h1:W4lzQxpdUPFVTjs6zCDFGyAbPfow28zbFU65QCQf+SY=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56/go.mod h1:Vp5X4tM0KmahplYOvdRqs2NY2qy1amZ89zZBm9CDENw=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
+github.com/replicatedhq/troubleshoot v0.9.26/go.mod h1:7MyY22gXMXTp1cUczegcXUeMsUJhtMzrrmlAi0aJu4s=
 github.com/replicatedhq/troubleshoot v0.9.27-0.20200310004312-d9625477d2a5/go.mod h1:hTdyiE0k5AjRO+bCgZcYKXDCw+m+RULTuw55i6FfFEY=
 github.com/replicatedhq/troubleshoot v0.9.27-0.20200310173216-983aaaacea80 h1:M0fiwncuiAQUa7QPc5OrHwE1JxWRyBx4jpSw55GgJGI=
 github.com/replicatedhq/troubleshoot v0.9.27-0.20200310173216-983aaaacea80/go.mod h1:7MyY22gXMXTp1cUczegcXUeMsUJhtMzrrmlAi0aJu4s=
@@ -902,6 +909,7 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmware-tanzu/velero v1.2.0 h1:q9WTE3P2wJqgeKhEzTgTTTxUT/2hewxn5Uc2wjSMi+g=
 github.com/vmware-tanzu/velero v1.2.0/go.mod h1:s+8IqUKWcprcMVOfZKNC+jFY3tr/ElJfaMCcAfhThts=
+github.com/vmware-tanzu/velero v1.3.1 h1:EB1yLonAYkTexbxINhqyz9S0gsbSgwsJbjFtxf2zkAA=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=

--- a/go.sum
+++ b/go.sum
@@ -752,6 +752,7 @@ github.com/replicatedhq/kots v1.13.10-0.20200317153303-89d5bfaddd77 h1:WyWMDo/B+
 github.com/replicatedhq/kots v1.13.10-0.20200317153303-89d5bfaddd77/go.mod h1:fKQZXHH3VyZcKzQPpy3MNA5rBkiiK9feb5TFBKu2qpA=
 github.com/replicatedhq/kotsadm/operator v0.0.0-20200319203633-86dcbbd1ab78 h1:ea4KHKGAz93Jh9vENjRm5MThOoxAaoInawlYABhd50E=
 github.com/replicatedhq/kotsadm/operator v0.0.0-20200319203633-86dcbbd1ab78/go.mod h1:NSqt331XhUNgvyb3/THH6lCnpB1NNM+7eGWWM4acW3U=
+github.com/replicatedhq/kotsadm/operator v0.0.0-20200319221914-592c0560c20f h1:cs++Qkmtum9XskrkkG0XPeSN8a+jXDOQ1LAR0y1tbqY=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56 h1:W4lzQxpdUPFVTjs6zCDFGyAbPfow28zbFU65QCQf+SY=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56/go.mod h1:Vp5X4tM0KmahplYOvdRqs2NY2qy1amZ89zZBm9CDENw=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -57,6 +57,7 @@ func Start() {
 	r.Path("/api/v1/app/{appSlug}/license").Methods("OPTIONS", "PUT").HandlerFunc(handlers.SyncLicense)
 	r.Path("/api/v1/app/{appSlug}/updatecheck").Methods("OPTIONS", "POST").HandlerFunc(handlers.AppUpdateCheck)
 	r.Path("/api/v1/app/airgap").Methods("OPTIONS", "POST").HandlerFunc(handlers.CreateAppFromAirgap)
+	r.Path("/api/v1/snapshot/{backup}/logs").Methods("OPTIONS", "GET").HandlerFunc(handlers.DownloadSnapshotLogs)
 
 	// TODO
 

--- a/pkg/handlers/snapshot.go
+++ b/pkg/handlers/snapshot.go
@@ -18,7 +18,6 @@ import (
 )
 
 func DownloadSnapshotLogs(w http.ResponseWriter, r *http.Request) {
-	println("here here")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Headers", "content-type, origin, accept, authorization")
 
@@ -118,8 +117,8 @@ func DownloadSnapshotLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	w.Header().Set("Content-Disposition", "attachment; filename=backup-logs.tar.gz")
-	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", "attachment; filename=snapshot-logs.tar.gz")
+	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
 	w.Header().Set("Content-Length", resp.Header.Get("Content-Length"))
 
 	_, err = io.Copy(w, resp.Body)

--- a/pkg/handlers/snapshot.go
+++ b/pkg/handlers/snapshot.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/replicatedhq/kotsadm/pkg/logger"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/typed/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/label"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+func DownloadSnapshotLogs(w http.ResponseWriter, r *http.Request) {
+	println("here here")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "content-type, origin, accept, authorization")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if err := requireValidSession(w, r); err != nil {
+		// header already written on error
+		logger.Error(err)
+		return
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(500)
+		return
+	}
+	velero, err := velerov1.NewForConfig(config)
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(500)
+		return
+	}
+
+	namespace := "velero" // TODO support alternative namespaces
+	backupName := mux.Vars(r)["backup"]
+	drName := fmt.Sprintf("backup-%s-%d", backupName, time.Now().Unix())
+	drName = label.GetValidName(drName)
+	dr := &v1.DownloadRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: drName,
+		},
+		Spec: v1.DownloadRequestSpec{
+			Target: v1.DownloadTarget{
+				Kind: "BackupLog",
+				Name: backupName,
+			},
+		},
+	}
+
+	_, err = velero.DownloadRequests(namespace).Create(dr)
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(500)
+		return
+	}
+
+	signedURL := ""
+	watcher, err := velero.DownloadRequests(namespace).Watch(metav1.ListOptions{})
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(500)
+		return
+	}
+	defer watcher.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	for {
+		if signedURL != "" {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			logger.Error(ctx.Err())
+			w.WriteHeader(500)
+			return
+		case e := <-watcher.ResultChan():
+			if e.Type != watch.Modified {
+				continue
+			}
+			dr, ok := e.Object.(*v1.DownloadRequest)
+			if !ok {
+				continue
+			}
+			if dr.Name != drName {
+				continue
+			}
+			if dr.Status.DownloadURL != "" {
+				signedURL = dr.Status.DownloadURL
+				break
+			}
+		}
+	}
+	if err := velero.DownloadRequests(namespace).Delete(drName, &metav1.DeleteOptions{}); err != nil {
+		logger.Error(err)
+		// continue
+	}
+
+	resp, err := http.Get(signedURL)
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(500)
+		return
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Disposition", "attachment; filename=backup-logs.tar.gz")
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Length", resp.Header.Get("Content-Length"))
+
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(500)
+		return
+	}
+}

--- a/pkg/handlers/snapshot.go
+++ b/pkg/handlers/snapshot.go
@@ -117,7 +117,7 @@ func DownloadSnapshotLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	w.Header().Set("Content-Disposition", "attachment; filename=snapshot-logs.tar.gz")
+	w.Header().Set("Content-Disposition", "attachment; filename=snapshot-logs.gz")
 	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
 	w.Header().Set("Content-Length", resp.Header.Get("Content-Length"))
 

--- a/web/src/components/apps/AppSnapshotDetail.jsx
+++ b/web/src/components/apps/AppSnapshotDetail.jsx
@@ -134,7 +134,6 @@ class AppSnapshotDetail extends Component {
       method: "GET",
       headers: {
         "Authorization": `${Utilities.getToken()}`,
-        "Content-Type": "application/gzip",
       },
     });
   }

--- a/web/src/components/apps/AppSnapshotDetail.jsx
+++ b/web/src/components/apps/AppSnapshotDetail.jsx
@@ -9,6 +9,7 @@ import moment from "moment";
 import Loader from "../shared/Loader";
 import { snapshotDetail } from "../../queries/SnapshotQueries";
 import ShowAllModal from "../modals/ShowAllModal";
+import { Utilities } from "../../utilities/utilities";
 
 class AppSnapshotDetail extends Component {
   state = {
@@ -123,6 +124,19 @@ class AppSnapshotDetail extends Component {
 
   toggleShowAllErrors = () => {
     this.setState({ showAllErrors: !this.state.showAllErrors });
+  }
+
+  downloadLogs = () => {
+    const name = this.props.snapshotDetail?.snapshotDetail?.name;
+    const link = `${window.env.API_ENDPOINT}/snapshot/${name}/logs`;  
+
+    fetch(link, {
+      method: "GET",
+      headers: {
+        "Authorization": `${Utilities.getToken()}`,
+        "Content-Type": "application/gzip",
+      },
+    });
   }
 
   renderOutputTabs = () => {
@@ -296,7 +310,7 @@ class AppSnapshotDetail extends Component {
           </div>
           <div className="flex-column u-lineHeight--normal u-textAlign--right">
             <p className="u-fontSize--normal u-fontWeight--normal u-marginBottom--5">Status: <span className={`status-indicator ${snapshotDetail?.snapshotDetail?.status.toLowerCase()} u-marginLeft--5`}>{snapshotDetail?.snapshotDetail?.status}</span></p>
-            <div className="u-fontSize--small"><span className="u-marginRight--5 u-fontWeight--medium u-color--chestnut">{`${snapshotDetail?.snapshotDetail?.warnings ? snapshotDetail?.snapshotDetail?.errors.length : 0} errors`}</span><span className="replicated-link">Download logs</span></div>
+            <div className="u-fontSize--small"><span className="u-marginRight--5 u-fontWeight--medium u-color--chestnut">{`${snapshotDetail?.snapshotDetail?.warnings ? snapshotDetail?.snapshotDetail?.errors.length : 0} errors`}</span><span className="replicated-link" onClick={() => this.downloadLogs()}>Download logs</span></div>
           </div>
         </div>
 


### PR DESCRIPTION
The handler is implemented in the Go API server and is authenticated
with a web session Auth header. It creates a velero/v1/DownloadRequest
and then watches it until the velero operator has added a signed URL to
its status where the logs can be downloaded. The handler then deletes
the DownloadRequest and pipes the logs file from the backend object
store to the browser.

The client currently uses fetch and does not treat the response as a
file. That will need to be fixed in another PR.