### PR TITLE
Fix snapshot restore wait

### DIFF
--- a/api/src/snapshots/resolvers/veleroClient.ts
+++ b/api/src/snapshots/resolvers/veleroClient.ts
@@ -266,6 +266,15 @@ export class VeleroClient {
     throw new Error(`Read Restore ${name} from namespace ${this.ns}: ${response.statusCode}`);
   }
 
+  async listRestoreNamespaces(name: string): Promise<string[]> {
+    const restore = await this.readRestore(name);
+    if (!restore) {
+      return [];
+    }
+    const backup = await this.readBackup(restore.spec.backupName);
+    return backup.spec.includedNamespaces || [];
+  }
+
   async listRestoreVolumes(name: string): Promise<RestoreVolume[]> {
     const q = {
       labelSelector: `velero.io/restore-name=${getValidName(name)}`,

--- a/api/src/sockets/kots/DeploySocket.ts
+++ b/api/src/sockets/kots/DeploySocket.ts
@@ -150,7 +150,7 @@ export class KotsDeploySocketService {
         break;
 
       case UndeployStatus.Failed:
-        logger.warn(`Restore ${app.restoreInProgressName} falied`);
+        logger.warn(`Restore ${app.restoreInProgressName} failed`);
         // TODO
         break;
 

--- a/api/src/sockets/kots/DeploySocket.ts
+++ b/api/src/sockets/kots/DeploySocket.ts
@@ -278,6 +278,7 @@ export class KotsDeploySocketService {
 
               const args = {
                 app_id: app.id,
+                app_slug: app.slug,
                 kubectl_version: kotsAppSpec ? kotsAppSpec.kubectlVersion : "",
                 additional_namespaces: kotsAppSpec ? kotsAppSpec.additionalNamespaces : [],
                 image_pull_secret: imagePullSecret,

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kots v1.14.2
+	github.com/replicatedhq/kotsadm/operator v0.0.0-20200407003758-1a04f863fce5 // indirect
 	github.com/replicatedhq/troubleshoot v0.9.27
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/segmentio/ksuid v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/replicatedhq/kotsadm
 go 1.12
 
 require (
-	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Microsoft/hcsshim v0.8.8-0.20200225064221-b400e4ffeccc // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aws/aws-sdk-go v1.25.18
@@ -13,7 +12,6 @@ require (
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.0
-	github.com/huandu/xstrings v1.3.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kubernetes-sigs/application v0.8.1 // indirect
 	github.com/lib/pq v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -466,6 +466,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -601,6 +602,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
+github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -682,6 +685,7 @@ github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/pact-foundation/pact-go v1.0.0-beta.5/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/go.sum
+++ b/go.sum
@@ -745,6 +745,8 @@ github.com/replicatedhq/kots v1.14.1 h1:qeARUI4cJpG1+z8080kbC5Puv5gUiX8EZTNYjvyK
 github.com/replicatedhq/kots v1.14.1/go.mod h1:VUHc86zPdn7QfV+IKcj7FyA1wUFrQYPHEeDI5oWj5x8=
 github.com/replicatedhq/kots v1.14.2 h1:gbtVJ7d8qo5qkSXR928A2XNIwJC8NabEuS/CovtYANQ=
 github.com/replicatedhq/kots v1.14.2/go.mod h1:VUHc86zPdn7QfV+IKcj7FyA1wUFrQYPHEeDI5oWj5x8=
+github.com/replicatedhq/kotsadm/operator v0.0.0-20200407003758-1a04f863fce5 h1:Mw6C6PWqQOYibpoW6cUHFKot8K/o+i6yfH+dN+rGXIg=
+github.com/replicatedhq/kotsadm/operator v0.0.0-20200407003758-1a04f863fce5/go.mod h1:qKoeHimtlfRpBlISUTZpKK0KsstONGTYO2q51wya/iM=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56 h1:W4lzQxpdUPFVTjs6zCDFGyAbPfow28zbFU65QCQf+SY=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56/go.mod h1:Vp5X4tM0KmahplYOvdRqs2NY2qy1amZ89zZBm9CDENw=
 github.com/replicatedhq/troubleshoot v0.9.27 h1:51ouEai9xSp7E9+Jbd+Oz1wxu5jFJbXSvLr3Vq6ivTk=

--- a/go.sum
+++ b/go.sum
@@ -471,6 +471,7 @@ github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mo
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/huandu/xstrings v1.3.0 h1:gvV6jG9dTgFEncxo+AF7PH6MZXi/vZl25owA/8Dg8Wo=
 github.com/huandu/xstrings v1.3.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -27,6 +27,7 @@ require (
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v0.17.4
 	k8s.io/helm v2.14.3+incompatible
+	sigs.k8s.io/controller-runtime v0.4.0
 )
 
 replace github.com/nicksnyder/go-i18n => github.com/nicksnyder/go-i18n v1.10.1

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/coreos/etcd v3.3.15+incompatible // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gorilla/websocket v1.4.0

--- a/operator/pkg/client/client.go
+++ b/operator/pkg/client/client.go
@@ -38,6 +38,7 @@ type ApplicationManifests struct {
 	Manifests            string   `json:"manifests"`
 	Wait                 bool     `json:"wait"`
 	ResultCallback       string   `json:"result_callback"`
+	ClearNamespaces      []string `json:"clear_namespaces"`
 }
 
 // DesiredState is what we receive from the kotsadm-api server
@@ -215,6 +216,7 @@ func (c *Client) registerHandlers(socketClient *socket.Client) error {
 
 	err = socketClient.On("deploy", func(h *socket.Channel, args ApplicationManifests) {
 		log.Println("received a deploy request")
+
 		if args.PreviousManifests != "" {
 			if err := c.diffAndRemovePreviousManifests(args); err != nil {
 				log.Printf("error diffing and removing previous manifests: %s", err.Error())

--- a/operator/pkg/client/client.go
+++ b/operator/pkg/client/client.go
@@ -29,6 +29,7 @@ var (
 
 type ApplicationManifests struct {
 	AppID                string   `json:"app_id"`
+	AppSlug              string   `json:"app_slug"`
 	KubectlVersion       string   `json:"kubectl_version"`
 	AdditionalNamespaces []string `json:"additional_namespaces"`
 	ImagePullSecret      string   `json:"image_pull_secret"`

--- a/operator/pkg/client/deploy.go
+++ b/operator/pkg/client/deploy.go
@@ -149,7 +149,7 @@ func (c *Client) ensureResourcesPresent(applicationManifests ApplicationManifest
 			}
 
 			log.Printf("dry run applying manifests(s) in requested namespace: %s", requestedNamespace)
-			dryrunStdout, dryrunStderr, dryRunErr := kubernetesApplier.Apply(requestedNamespace, docs, true, applicationManifests.Wait)
+			dryrunStdout, dryrunStderr, dryRunErr := kubernetesApplier.Apply(requestedNamespace, applicationManifests.AppSlug, docs, true, applicationManifests.Wait)
 			if dryRunErr != nil {
 				log.Printf("stdout (dryrun) = %s", dryrunStdout)
 				log.Printf("stderr (dryrun) = %s", dryrunStderr)
@@ -174,7 +174,7 @@ func (c *Client) ensureResourcesPresent(applicationManifests ApplicationManifest
 
 		// CRDs don't have namespaces, so we can skip splitting
 
-		applyStdout, applyStderr, applyErr := kubernetesApplier.Apply("", customResourceDefinitions, false, applicationManifests.Wait)
+		applyStdout, applyStderr, applyErr := kubernetesApplier.Apply("", applicationManifests.AppSlug, customResourceDefinitions, false, applicationManifests.Wait)
 		if applyErr != nil {
 			log.Printf("stdout (apply CRDS) = %s", applyStdout)
 			log.Printf("stderr (apply CRDS) = %s", applyStderr)
@@ -206,7 +206,7 @@ func (c *Client) ensureResourcesPresent(applicationManifests ApplicationManifest
 		}
 
 		log.Printf("applying manifest(s) in namespace %s", requestedNamespace)
-		applyStdout, applyStderr, applyErr := kubernetesApplier.Apply(requestedNamespace, docs, false, applicationManifests.Wait)
+		applyStdout, applyStderr, applyErr := kubernetesApplier.Apply(requestedNamespace, applicationManifests.AppSlug, docs, false, applicationManifests.Wait)
 		if applyErr != nil {
 			log.Printf("stdout (apply) = %s", applyStdout)
 			log.Printf("stderr (apply) = %s", applyStderr)

--- a/operator/pkg/client/deploy.go
+++ b/operator/pkg/client/deploy.go
@@ -84,8 +84,6 @@ func (c *Client) diffAndRemovePreviousManifests(applicationManifests Application
 		}
 	}
 
-	// TODO remove
-	log.Printf("ClearNamespace: %+v", applicationManifests.ClearNamespaces)
 	for _, namespace := range applicationManifests.ClearNamespaces {
 		log.Printf("Ensuring all %s objects have been removed from namespace %s\n", applicationManifests.AppSlug, namespace)
 		for i := 10; i >= 0; i-- {
@@ -298,7 +296,6 @@ func (c *Client) clearNamespace(slug string, namespace string) (bool, error) {
 	clear := true
 	for gvr := range gvrs {
 		s := fmt.Sprintf("%s/%s/%s", gvr.Group, gvr.Version, gvr.Resource)
-		log.Println(s)
 		if skip.Has(s) {
 			continue
 		}


### PR DESCRIPTION
Before starting the restore, send a list of namespaces to the operator to be cleared. The namespaces come from the spec of the Backup that is being used for the restore. The operator will use discovery and dynamic clients to list all resources in those namespaces and delete anything that has a `kots.io/app-slug` annotation matching the app that is being restored. This is necessary for deleting PVCs created by StatefulSets. The operator will not report the undeploy is complete untill all resources for the app are gone from the namespaces.

Fix the restore sequence. The current deployed sequence being snapshotted should come from the app_downstream table, not the app table.

Fix the prefix in the kotsadm-velero-backend BackupStorageLocation template to prevent velero pod getting into a crash loop.