### PR TITLE
Create support bundle from failed and partiallyfailed snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kots v1.15.0-beta.1
-	github.com/replicatedhq/troubleshoot v0.9.27
+	github.com/replicatedhq/troubleshoot v0.9.29-0.20200414221457-f06cd9e4a26e
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/segmentio/ksuid v1.0.2
 	github.com/sergi/go-diff v1.0.0
@@ -41,6 +41,7 @@ require (
 	gopkg.in/go-playground/assert.v1 v1.2.1
 	gopkg.in/ini.v1 v1.51.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible

--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,7 @@ github.com/go-toolsmith/pkgload v1.0.0/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Il
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
 github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
+github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
@@ -724,6 +725,7 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -745,6 +747,8 @@ github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56 h1:W4l
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56/go.mod h1:Vp5X4tM0KmahplYOvdRqs2NY2qy1amZ89zZBm9CDENw=
 github.com/replicatedhq/troubleshoot v0.9.27 h1:51ouEai9xSp7E9+Jbd+Oz1wxu5jFJbXSvLr3Vq6ivTk=
 github.com/replicatedhq/troubleshoot v0.9.27/go.mod h1:g9GiMrUk+s9j2PbbaJ4vav8yAakCPg4c9GBSdVtUxyk=
+github.com/replicatedhq/troubleshoot v0.9.29-0.20200414221457-f06cd9e4a26e h1:rD94CzyTUIjyOjNTVeoQDZVetb02i2tSIZ/CAcdAwk4=
+github.com/replicatedhq/troubleshoot v0.9.29-0.20200414221457-f06cd9e4a26e/go.mod h1:1DLEO9EeR+OSTrvSUocmwg5YeH27N9ocXszPdZE716g=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq/go.mod h1:Txa7LopbYCU8aRgmNe0n+y/EPMz50NbCPcVVJBquwag=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
@@ -1287,6 +1291,7 @@ mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIa
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskXg5OFSrilMRUkD8ePJpHKDPaeY=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/application v0.8.1 h1:eZrWuEPIOyD8RLL3GYAo2smBEa+m51eQcTJicXhcqnI=
 sigs.k8s.io/application v0.8.1/go.mod h1:9C86g0wiFn8jtZjgJepSx188uJeWLGWTbcCycu5p8mU=
 sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
@@ -1298,10 +1303,13 @@ sigs.k8s.io/kustomize/api v0.3.2 h1:64gvYVAvqe2fNfcTevtXh/GmLwVwHIcJ2Z5HBMfjncs=
 sigs.k8s.io/kustomize/api v0.3.2/go.mod h1:A+ATnlHqzictQfQC1q3KB/T6MSr0UWQsrrLxMWkge2E=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
+sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/testing_frameworks v0.1.2 h1:vK0+tvjF0BZ/RYFeZ1E6BYBwHJJXhjuZ3TdsEKH+UQM=
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/go.sum
+++ b/go.sum
@@ -451,12 +451,14 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-getter v1.3.1-0.20190627223108-da0323b9545e h1:6krcdHPiS+aIP9XKzJzSahfjD7jG7Z+4+opm0z39V1M=
 github.com/hashicorp/go-getter v1.3.1-0.20190627223108-da0323b9545e/go.mod h1:/O1k/AizTN0QmfEKknCYGvICeyKUDqCYA8vvWtGWDeQ=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/replicatedhq/kotsadm/pkg/handlers"
+	"github.com/replicatedhq/kotsadm/pkg/informers"
 	"github.com/replicatedhq/kotsadm/pkg/version"
 )
 
@@ -19,6 +20,10 @@ func Start() {
 	// NOTE: This should be removed in 1.15 or a later version.
 	if err := version.PopulateMissingDownstreamVersions(); err != nil {
 		log.Println("Failed to run migrations", err)
+	}
+
+	if err := informers.Start(); err != nil {
+		log.Println("Failed to start informers", err)
 	}
 
 	u, err := url.Parse("http://kotsadm-api-node:3000")

--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -1,0 +1,91 @@
+package informers
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/logger"
+	"github.com/replicatedhq/kotsadm/pkg/supportbundle"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	veleroclientv1 "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/typed/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// Start will start the kots informers
+// These are not the application level informers, but they are the general purpose KOTS
+// informers. For example, we want to watch Velero Backup
+// in order to handle out-of-band updates
+func Start() error {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to get cluster config")
+	}
+
+	veleroClient, err := veleroclientv1.NewForConfig(cfg)
+	if err != nil {
+		return errors.Wrap(err, "failed to create velero clientset")
+	}
+
+	backupWatch, err := veleroClient.Backups("").Watch(metav1.ListOptions{ResourceVersion: "0"})
+	if err != nil {
+		return errors.Wrap(err, "failed to watch")
+	}
+
+	go func() {
+		ch := backupWatch.ResultChan()
+		for {
+			obj, ok := <-ch
+			if !ok {
+				break
+			}
+			if obj.Type == watch.Modified {
+				backup, ok := obj.Object.(*velerov1.Backup)
+				if !ok {
+					logger.Errorf("failed to cast obj to backup")
+				}
+
+				if backup.Status.Phase == velerov1.BackupPhaseFailed || backup.Status.Phase == velerov1.BackupPhasePartiallyFailed {
+					_, ok := backup.Annotations["kots.io/support-bundle-requested"]
+					if !ok {
+						// here.  finally..   request a support bundle for this
+						logger.Debugf("requesting support bundle for failed or partially failed backup %s", backup.Name)
+
+						appID, ok := backup.Annotations["kots.io/app-id"]
+						if !ok {
+							logger.Errorf("failed to find app id anotation on backup")
+						}
+
+						backup.Annotations["kots.io/support-bundle-requested"] = time.Now().UTC().Format(time.RFC3339)
+
+						if _, err := veleroClient.Backups(backup.Namespace).Update(backup); err != nil {
+							logger.Error(err)
+							break
+						}
+
+						supportBundleID, err := supportbundle.CreateBundleForBackup(appID, backup.Name, backup.Namespace)
+						if err != nil {
+							logger.Error(err)
+							break
+						}
+
+						updatedBackup, err := veleroClient.Backups(backup.Namespace).Get(backup.Name, metav1.GetOptions{})
+						if err != nil {
+							logger.Error(err)
+							break
+						}
+
+						updatedBackup.Annotations["kots.io/support-bundle-id"] = supportBundleID
+						if _, err := veleroClient.Backups(backup.Namespace).Update(updatedBackup); err != nil {
+							logger.Error(err)
+							break
+						}
+					}
+				}
+			}
+		}
+	}()
+
+	return nil
+}

--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -61,25 +61,25 @@ func Start() error {
 
 						if _, err := veleroClient.Backups(backup.Namespace).Update(backup); err != nil {
 							logger.Error(err)
-							break
+							continue
 						}
 
 						supportBundleID, err := supportbundle.CreateBundleForBackup(appID, backup.Name, backup.Namespace)
 						if err != nil {
 							logger.Error(err)
-							break
+							continue
 						}
 
 						updatedBackup, err := veleroClient.Backups(backup.Namespace).Get(backup.Name, metav1.GetOptions{})
 						if err != nil {
 							logger.Error(err)
-							break
+							continue
 						}
 
 						updatedBackup.Annotations["kots.io/support-bundle-id"] = supportBundleID
 						if _, err := veleroClient.Backups(backup.Namespace).Update(updatedBackup); err != nil {
 							logger.Error(err)
-							break
+							continue
 						}
 					}
 				}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -21,6 +21,12 @@ func Error(err error) {
 	sugar.Error(err)
 }
 
+func Errorf(template string, args ...interface{}) {
+	defer log.Sync()
+	sugar := log.Sugar()
+	sugar.Errorf(template, args)
+}
+
 func Debug(msg string, fields ...zap.Field) {
 	defer log.Sync()
 	sugar := log.Sugar()

--- a/pkg/snapshot/backup.go
+++ b/pkg/snapshot/backup.go
@@ -166,6 +166,11 @@ func ListBackupsForApp(appID string) ([]*types.Backup, error) {
 			backup.Trigger = trigger
 		}
 
+		supportBundleID, ok := veleroBackup.Annotations["kots.io/support-bundle-id"]
+		if ok {
+			backup.SupportBundleID = supportBundleID
+		}
+
 		volumeCount, volumeCountOk := veleroBackup.Annotations["kots.io/snapshot-volume-count"]
 		if volumeCountOk {
 			i, err := strconv.Atoi(volumeCount)

--- a/pkg/snapshot/types/types.go
+++ b/pkg/snapshot/types/types.go
@@ -54,5 +54,5 @@ type Backup struct {
 	VolumeSuccessCount int        `json:"volumeSuccessCount"`
 	VolumeBytes        int64      `json:"volumeBytes"`
 	VolumeSizeHuman    string     `json:"volumeSizeHuman"`
-	AnalyzeID          string     `json:"analyzeId,omitempty"`
+	SupportBundleID    string     `json:"supportBundleId,omitempty"`
 }

--- a/pkg/snapshot/types/types.go
+++ b/pkg/snapshot/types/types.go
@@ -54,4 +54,5 @@ type Backup struct {
 	VolumeSuccessCount int        `json:"volumeSuccessCount"`
 	VolumeBytes        int64      `json:"volumeBytes"`
 	VolumeSizeHuman    string     `json:"volumeSizeHuman"`
+	AnalyzeID          string     `json:"analyzeId,omitempty"`
 }

--- a/pkg/snapshot/velero.go
+++ b/pkg/snapshot/velero.go
@@ -1,7 +1,6 @@
 package snapshot
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -105,7 +104,6 @@ DeploymentFound:
 		if len(matches) == 5 {
 			status := "NotReady"
 
-			fmt.Printf("status = %#v\n", daemonset.Status)
 			if daemonset.Status.NumberAvailable > 0 {
 				if daemonset.Status.NumberUnavailable == 0 {
 					status = "Ready"

--- a/pkg/supportbundle/backup.go
+++ b/pkg/supportbundle/backup.go
@@ -1,0 +1,192 @@
+package supportbundle
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/mholt/archiver"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/logger"
+	troubleshootanalyze "github.com/replicatedhq/troubleshoot/pkg/analyze"
+	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
+	troubleshootcollect "github.com/replicatedhq/troubleshoot/pkg/collect"
+	troubleshootversion "github.com/replicatedhq/troubleshoot/pkg/version"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+	"k8s.io/client-go/rest"
+)
+
+func CreateBundleForBackup(appID string, backupName string, backupNamespace string) (string, error) {
+	logger.Debug("executing support bundle for backup",
+		zap.String("backupName", backupName),
+		zap.String("backupNamespace", backupNamespace))
+
+	progressChan := make(chan interface{}, 0)
+	defer close(progressChan)
+
+	go func() {
+		for {
+			msg, ok := <-progressChan
+			if ok {
+				logger.Debugf("%v", msg)
+			} else {
+				return
+			}
+		}
+	}()
+
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read in cluster config")
+	}
+
+	var collectors troubleshootcollect.Collectors
+	// TODO define collectors
+	collectors = append(collectors, &troubleshootcollect.Collector{
+		Collect: &troubleshootv1beta1.Collect{
+			ClusterInfo: &troubleshootv1beta1.ClusterInfo{},
+		},
+		Redact:       true,
+		ClientConfig: restConfig,
+		Namespace:    backupNamespace,
+	})
+
+	// make a temp file to store the bundle in
+	bundlePath, err := ioutil.TempDir("", "troubleshoot")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temp dir")
+	}
+	defer os.RemoveAll(bundlePath)
+
+	if err = writeVersionFile(bundlePath); err != nil {
+		return "", errors.Wrap(err, "failed to write version file")
+	}
+
+	// Run preflights collectors synchronously
+	for _, collector := range collectors {
+		if len(collector.RBACErrors) > 0 {
+			// don't skip clusterResources collector due to RBAC issues
+			if collector.Collect.ClusterResources == nil {
+				progressChan <- fmt.Sprintf("skipping collector %s with insufficient RBAC permissions", collector.GetDisplayName())
+				continue
+			}
+		}
+
+		progressChan <- collector.GetDisplayName()
+
+		result, err := collector.RunCollectorSync()
+		if err != nil {
+			progressChan <- fmt.Errorf("failed to run collector %q: %v", collector.GetDisplayName(), err)
+			continue
+		}
+
+		if result != nil {
+			err = saveCollectorOutput(result, bundlePath)
+			if err != nil {
+				progressChan <- fmt.Errorf("failed to parse collector spec %q: %v", collector.GetDisplayName(), err)
+				continue
+			}
+		}
+	}
+
+	// create an archive of this bundle
+	supportBundleArchivePath, err := ioutil.TempDir("", "kotsadm")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create archive dir")
+	}
+	defer os.RemoveAll(supportBundleArchivePath)
+
+	if err = tarSupportBundleDir(bundlePath, filepath.Join(supportBundleArchivePath, "support-bundle.tar.gz")); err != nil {
+		return "", errors.Wrap(err, "failed to create support bundle archive")
+	}
+
+	// we have a support bundle...
+	// store it
+	supportBundle, err := CreateBundle(
+		fmt.Sprintf("backup-%s", backupName),
+		appID,
+		filepath.Join(supportBundleArchivePath, "support-bundle.tar.gz"))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create support bundle")
+	}
+
+	// analyze it
+	// TODO define analyzers
+	analyzeResult, err := troubleshootanalyze.DownloadAndAnalyze(filepath.Join(supportBundleArchivePath, "support-bundle.tar.gz"), "")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to analyze")
+	}
+
+	fmt.Printf("\n\n\n----> %#v\n\n\n", analyzeResult)
+	return supportBundle.ID, nil
+}
+
+func tarSupportBundleDir(inputDir string, outputFilename string) error {
+	tarGz := archiver.TarGz{
+		Tar: &archiver.Tar{
+			ImplicitTopLevelFolder: false,
+		},
+	}
+
+	paths := []string{
+		filepath.Join(inputDir, "version.yaml"), // version file should be first in tar archive for quick extraction
+	}
+
+	topLevelFiles, err := ioutil.ReadDir(inputDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to list bundle directory contents")
+	}
+	for _, f := range topLevelFiles {
+		if f.Name() == "version.yaml" {
+			continue
+		}
+		paths = append(paths, filepath.Join(inputDir, f.Name()))
+	}
+
+	if err := tarGz.Archive(paths, outputFilename); err != nil {
+		return errors.Wrap(err, "failed to create archive")
+	}
+
+	return nil
+}
+
+func saveCollectorOutput(output map[string][]byte, bundlePath string) error {
+	for filename, maybeContents := range output {
+		fileDir, fileName := filepath.Split(filename)
+		outPath := filepath.Join(bundlePath, fileDir)
+
+		if err := os.MkdirAll(outPath, 0777); err != nil {
+			return errors.Wrap(err, "failed to create output file")
+		}
+
+		if err := ioutil.WriteFile(filepath.Join(outPath, fileName), maybeContents, 0644); err != nil {
+			return errors.Wrap(err, "failed to write file")
+		}
+	}
+
+	return nil
+}
+
+func writeVersionFile(path string) error {
+	version := troubleshootv1beta1.SupportBundleVersion{
+		ApiVersion: "troubleshoot.replicated.com/v1beta1",
+		Kind:       "SupportBundle",
+		Spec: troubleshootv1beta1.SupportBundleVersionSpec{
+			VersionNumber: troubleshootversion.Version(),
+		},
+	}
+	b, err := yaml.Marshal(version)
+	if err != nil {
+		return err
+	}
+
+	filename := filepath.Join(path, "version.yaml")
+	err = ioutil.WriteFile(filename, b, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/supportbundle/backup.go
+++ b/pkg/supportbundle/backup.go
@@ -120,6 +120,10 @@ func CreateBundleForBackup(appID string, backupName string, backupNamespace stri
 	}
 
 	fmt.Printf("\n\n\n----> %#v\n\n\n", analyzeResult)
+
+	if err := SetBundleStatus(supportBundle.ID, "analyzed"); err != nil {
+		return "", errors.Wrap(err, "failed to update bundle status")
+	}
 	return supportBundle.ID, nil
 }
 

--- a/pkg/supportbundle/filetree.go
+++ b/pkg/supportbundle/filetree.go
@@ -1,15 +1,119 @@
 package supportbundle
 
-import "github.com/replicatedhq/kotsadm/pkg/supportbundle/types"
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mholt/archiver"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/supportbundle/types"
+)
 
 func archiveToFileTree(archivePath string) (*types.FileTree, error) {
-	ft := types.FileTree{
-		Nodes: []types.FileTreeNode{
-			{
-				Path: "test",
-				Name: "test",
-			},
+	workDir, err := ioutil.TempDir("", "kotsadm")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create workdir")
+	}
+	defer os.RemoveAll(workDir)
+
+	// extract the current archive to this root
+	tarGz := &archiver.TarGz{
+		Tar: &archiver.Tar{
+			ImplicitTopLevelFolder: false,
 		},
 	}
+	if err := tarGz.Unarchive(archivePath, workDir); err != nil {
+		return nil, errors.Wrap(err, "failed to unarchive")
+	}
+
+	directories := []string{}
+	files := []string{}
+
+	err = filepath.Walk(workDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if len(path) <= len(workDir) {
+			return nil
+		}
+
+		if info.IsDir() {
+			directories = append(directories, path[len(workDir)+1:])
+			return nil
+		}
+
+		files = append(files, path[len(workDir)+1:])
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to walk")
+	}
+
+	ft := types.FileTree{
+		Nodes: []types.FileTreeNode{},
+	}
+
+	for _, directory := range directories {
+		if !strings.Contains(directory, string(os.PathSeparator)) {
+			node, err := getDirectoryNode(directory, directories, files)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get directory node")
+			}
+
+			ft.Nodes = append(ft.Nodes, *node)
+		}
+	}
+
+	for _, file := range files {
+		if !strings.Contains(file, string(os.PathSeparator)) {
+			node := types.FileTreeNode{
+				Name: file,
+				Path: file,
+			}
+
+			ft.Nodes = append(ft.Nodes, node)
+		}
+	}
+
 	return &ft, nil
+}
+
+func getDirectoryNode(directory string, directories []string, files []string) (*types.FileTreeNode, error) {
+	node := types.FileTreeNode{
+		Name: directory,
+		Path: directory,
+	}
+
+	children := []types.FileTreeNode{}
+
+	for _, file := range files {
+		d, f := filepath.Split(file)
+		if strings.TrimSuffix(d, string(os.PathSeparator)) == directory {
+			child := types.FileTreeNode{
+				Name: f,
+				Path: file,
+			}
+			children = append(children, child)
+		}
+	}
+
+	for _, d := range directories {
+		if strings.HasPrefix(d, directory) && d != directory {
+			child, err := getDirectoryNode(d, directories, files)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to recursively call getDirectoryNode")
+			}
+
+			children = append(children, *child)
+		}
+	}
+
+	if len(children) > 0 {
+		node.Children = children
+	}
+
+	return &node, nil
 }

--- a/pkg/supportbundle/filetree.go
+++ b/pkg/supportbundle/filetree.go
@@ -1,0 +1,15 @@
+package supportbundle
+
+import "github.com/replicatedhq/kotsadm/pkg/supportbundle/types"
+
+func archiveToFileTree(archivePath string) (*types.FileTree, error) {
+	ft := types.FileTree{
+		Nodes: []types.FileTreeNode{
+			{
+				Path: "test",
+				Name: "test",
+			},
+		},
+	}
+	return &ft, nil
+}

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -1,24 +1,63 @@
 package supportbundle
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kotsadm/pkg/persistence"
 	"github.com/replicatedhq/kotsadm/pkg/supportbundle/types"
 	"github.com/segmentio/ksuid"
 )
 
-func CreateBundle(bundleSlug string, appID string, archivePath string) (*types.SupportBundle, error) {
+func SetBundleStatus(id string, status string) error {
 	db := persistence.MustGetPGSession()
-	query := `insert into supportbundle (id, slug, watch_id, size, status, created_at) values ($1, $2, $3, $4, $5, $6)`
+	query := `update supportbundle set status = $1 where id = $2`
+
+	_, err := db.Exec(query, status, id)
+	if err != nil {
+		return errors.Wrap(err, "failed to insert support bundle")
+	}
+
+	return nil
+}
+
+func CreateBundle(requestedID string, appID string, archivePath string) (*types.SupportBundle, error) {
+	fi, err := os.Stat(archivePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read archive")
+	}
 
 	id := ksuid.New().String()
+	if requestedID != "" {
+		id = requestedID
+	}
 
-	// TODO
 	// upload the file to s3
+	if err := uploadBundleToS3(id, archivePath); err != nil {
+		return nil, errors.Wrap(err, "failed to upload to s3")
+	}
 
-	_, err := db.Exec(query, id, bundleSlug, appID, 0, "", time.Now())
+	fileTree, err := archiveToFileTree(archivePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate file tree")
+	}
+
+	marshaledTree, err := json.Marshal(fileTree.Nodes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal tree index")
+	}
+
+	db := persistence.MustGetPGSession()
+	query := `insert into supportbundle (id, slug, watch_id, size, status, created_at, tree_index) values ($1, $2, $3, $4, $5, $6, $7)`
+
+	_, err = db.Exec(query, id, id, appID, fi.Size(), "uploaded", time.Now(), marshaledTree)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to insert support bundle")
 	}
@@ -26,4 +65,42 @@ func CreateBundle(bundleSlug string, appID string, archivePath string) (*types.S
 	return &types.SupportBundle{
 		ID: id,
 	}, nil
+}
+
+func uploadBundleToS3(id string, archivePath string) error {
+	forcePathStyle := false
+	if os.Getenv("S3_BUCKET_ENDPOINT") == "true" {
+		forcePathStyle = true
+	}
+
+	bucket := aws.String(os.Getenv("S3_BUCKET_NAME"))
+	key := aws.String(filepath.Join("supportbundles", id, "supportbundle.tar.gz"))
+
+	s3Config := &aws.Config{
+		Credentials:      credentials.NewStaticCredentials(os.Getenv("S3_ACCESS_KEY_ID"), os.Getenv("S3_SECRET_ACCESS_KEY"), ""),
+		Endpoint:         aws.String(os.Getenv("S3_ENDPOINT")),
+		Region:           aws.String("us-east-1"),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(forcePathStyle),
+	}
+
+	newSession := awssession.New(s3Config)
+
+	s3Client := s3.New(newSession)
+
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to open archive file")
+	}
+
+	_, err = s3Client.PutObject(&s3.PutObjectInput{
+		Body:   f,
+		Bucket: bucket,
+		Key:    key,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to upload to s3")
+	}
+
+	return nil
 }

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -1,0 +1,29 @@
+package supportbundle
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kotsadm/pkg/persistence"
+	"github.com/replicatedhq/kotsadm/pkg/supportbundle/types"
+	"github.com/segmentio/ksuid"
+)
+
+func CreateBundle(bundleSlug string, appID string, archivePath string) (*types.SupportBundle, error) {
+	db := persistence.MustGetPGSession()
+	query := `insert into supportbundle (id, slug, watch_id, size, status, created_at) values ($1, $2, $3, $4, $5, $6)`
+
+	id := ksuid.New().String()
+
+	// TODO
+	// upload the file to s3
+
+	_, err := db.Exec(query, id, bundleSlug, appID, 0, "", time.Now())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to insert support bundle")
+	}
+
+	return &types.SupportBundle{
+		ID: id,
+	}, nil
+}

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -2,7 +2,6 @@ package supportbundle
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -61,7 +60,6 @@ func CreateBundle(requestedID string, appID string, archivePath string) (*types.
 		return nil, errors.Wrap(err, "failed to marshal tree index")
 	}
 
-	fmt.Printf("\n\n\n%s\n\n\n", marshaledTree)
 	db := persistence.MustGetPGSession()
 	query := `insert into supportbundle (id, slug, watch_id, size, status, created_at, tree_index) values ($1, $2, $3, $4, $5, $6, $7)`
 

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -2,6 +2,7 @@ package supportbundle
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -54,6 +55,7 @@ func CreateBundle(requestedID string, appID string, archivePath string) (*types.
 		return nil, errors.Wrap(err, "failed to marshal tree index")
 	}
 
+	fmt.Printf("\n\n\n%s\n\n\n", marshaledTree)
 	db := persistence.MustGetPGSession()
 	query := `insert into supportbundle (id, slug, watch_id, size, status, created_at, tree_index) values ($1, $2, $3, $4, $5, $6, $7)`
 

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -17,13 +17,19 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
-func SetBundleStatus(id string, status string) error {
+func SetBundleAnalysis(id string, insights []byte) error {
 	db := persistence.MustGetPGSession()
 	query := `update supportbundle set status = $1 where id = $2`
 
-	_, err := db.Exec(query, status, id)
+	_, err := db.Exec(query, "analyzed", id)
 	if err != nil {
 		return errors.Wrap(err, "failed to insert support bundle")
+	}
+
+	query = `insert into supportbundle_analysis (id, supportbundle_id, error, max_severity, insights, created_at) values ($1, $2, null, null, $3, $4)`
+	_, err = db.Exec(query, ksuid.New().String(), id, insights, time.Now())
+	if err != nil {
+		return errors.Wrap(err, "failed to insert insights")
 	}
 
 	return nil

--- a/pkg/supportbundle/types/types.go
+++ b/pkg/supportbundle/types/types.go
@@ -3,3 +3,13 @@ package types
 type SupportBundle struct {
 	ID string `json:"id"`
 }
+
+type FileTree struct {
+	Nodes []FileTreeNode `json:",inline"`
+}
+
+type FileTreeNode struct {
+	Name     string         `json:"name"`
+	Path     string         `json:"path"`
+	Children []FileTreeNode `json:"children,omitempty"`
+}

--- a/pkg/supportbundle/types/types.go
+++ b/pkg/supportbundle/types/types.go
@@ -1,0 +1,5 @@
+package types
+
+type SupportBundle struct {
+	ID string `json:"id"`
+}

--- a/web/src/components/apps/AppSnapshotRow.jsx
+++ b/web/src/components/apps/AppSnapshotRow.jsx
@@ -17,6 +17,16 @@ class AppShanpshotRow extends React.Component {
     this.props.toggleRestoreModal(snapshot);
   }
 
+  snapshotStatusToDisplayName = status => {
+    // The front end replacessome status values with user friendly messages
+    switch (status) {
+      case "PartiallyFailed":
+        return "Incomplete (Failed)";
+    }
+
+    return status;
+  }
+
   render() {
     const { appSlug, snapshot } = this.props;
     const isExpired = dayjs(new Date()).isSameOrAfter(snapshot.expiresAt);
@@ -33,8 +43,9 @@ class AppShanpshotRow extends React.Component {
               <p className="u-fontSize--normal u-color--doveGray u-fontWeight--bold u-lineHeight--normal u-marginRight--20"><span className="u-fontWeight--normal u-color--dustyGray">Started:</span> {Utilities.dateFormat(snapshot.startedAt, "MMM D, YYYY h:mm A")}</p>
               <p className="u-fontSize--normal u-color--doveGray u-fontWeight--bold u-lineHeight--normal u-marginRight--20"><span className="u-fontWeight--normal u-color--dustyGray">Finished:</span> {snapshot.finishedAt ? Utilities.dateFormat(snapshot.finishedAt, "MMM D, YYYY h:mm A") : "TBD"}</p>
               <div>
-                <span className={`status-indicator ${snapshot.status.toLowerCase()}`}>{snapshot.status}</span>
+                <span className={`status-indicator ${snapshot.status.toLowerCase()}`}>{this.snapshotStatusToDisplayName(snapshot.status)}</span>
               </div>
+              <Link className={`replicated-link u-marginLeft--5 u-fontSize--small ${snapshot.status.analyzeId ? "" : "u-display--none"}`} to={`/app/${appSlug}/troubleshoot/analyze/${snapshot.status.analyzeId}`}>Troubleshoot</Link>
             </div>
           </div>
           <div className="flex flex-auto alignItems--center u-marginTop--5">

--- a/web/src/components/apps/AppSnapshotRow.jsx
+++ b/web/src/components/apps/AppSnapshotRow.jsx
@@ -45,7 +45,7 @@ class AppShanpshotRow extends React.Component {
               <div>
                 <span className={`status-indicator ${snapshot.status.toLowerCase()}`}>{this.snapshotStatusToDisplayName(snapshot.status)}</span>
               </div>
-              <Link className={`replicated-link u-marginLeft--5 u-fontSize--small ${snapshot.status.analyzeId ? "" : "u-display--none"}`} to={`/app/${appSlug}/troubleshoot/analyze/${snapshot.status.analyzeId}`}>Troubleshoot</Link>
+              <Link className={`replicated-link u-marginLeft--5 u-fontSize--small ${snapshot.supportBundleId ? "" : "u-display--none"}`} to={`/app/${appSlug}/troubleshoot/analyze/${snapshot.supportBundleId}`}>Troubleshoot</Link>
             </div>
           </div>
           <div className="flex flex-auto alignItems--center u-marginTop--5">


### PR DESCRIPTION
This PR adds an informer to velero's backup types. When the status changes to Failed or PartiallyFailed, if this is a kots generate backup, kots will now generate a support bundle using a specific collectors and analyzers and link to troubleshooting from the failed snapshot.

There are still some things to do:

1. We need a set of collectors.  
1. We need analyzers
1. The informer starts when kotsadm starts. This works, but will likely be a problem if velero is not installed and then is installed later. We need the "detect velero" to restart the informer, if the informer didn't start at startup