### PR TITLE
Add a longer timeout for Skaffold

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -58,6 +58,7 @@ build:
         dockerfile: ./Dockerfile.skaffold
 
 deploy:
+  statusCheckDeadlineSeconds: 240
   kustomize:
     paths:
       - "./kustomize/overlays/dev"


### PR DESCRIPTION
this prevents skaffold from timing out when postgres and the migrations take a while to run in the dev env