### PR TITLE
failure to retrieve redact spec prevents making a support bundle

### DIFF
--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -43,9 +43,9 @@ func GetDefaultTroubleshoot(w http.ResponseWriter, r *http.Request) {
 	fullTroubleshoot := string(defaultBytes)
 	redactSpec, _, err := redact.GetRedactSpec()
 	if err != nil {
-		// this isn't fatal, since we can just omit the redact spec
-		redactSpec = ""
 		logger.Error(err)
+		w.WriteHeader(500)
+		return
 	}
 	if redactSpec != "" {
 		fullTroubleshoot = fmt.Sprintf("%s\n---\n%s", string(defaultBytes), redactSpec)
@@ -132,9 +132,9 @@ func GetTroubleshoot(w http.ResponseWriter, r *http.Request) {
 	fullTroubleshoot := string(specBytes)
 	redactSpec, _, err := redact.GetRedactSpec()
 	if err != nil {
-		// this isn't fatal, since we can just omit the redact spec
-		redactSpec = ""
 		logger.Error(err)
+		w.WriteHeader(500)
+		return
 	}
 	if redactSpec != "" {
 		fullTroubleshoot = fmt.Sprintf("%s\n---\n%s", string(specBytes), redactSpec)


### PR DESCRIPTION
if no redact spec exists, that's fine - but if we get an error retrieving the spec, that's fatal
we can't allow creating a bundle without a redact spec if a redact spec is set