### PR TITLE
use Output, not CombinedOutput, when running kustomize

### DIFF
--- a/pkg/downstream/diff.go
+++ b/pkg/downstream/diff.go
@@ -44,11 +44,11 @@ func diffContent(updatedContent string, baseContent string) (int, int, error) {
 // archivedirs
 func DiffAppVersionsForDownstream(downstreamName string, archive string, diffBasePath string, kustomizeVersion string) (*Diff, error) {
 	// kustomize build both of these archives before diffing
-	archiveOutput, err := exec.Command(fmt.Sprintf("kustomize%s", kustomizeVersion), "build", filepath.Join(archive, "overlays", "downstreams", downstreamName)).CombinedOutput()
+	archiveOutput, err := exec.Command(fmt.Sprintf("kustomize%s", kustomizeVersion), "build", filepath.Join(archive, "overlays", "downstreams", downstreamName)).Output()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to run kustomize on archive dir")
 	}
-	baseOutput, err := exec.Command(fmt.Sprintf("kustomize%s", kustomizeVersion), "build", filepath.Join(diffBasePath, "overlays", "downstreams", downstreamName)).CombinedOutput()
+	baseOutput, err := exec.Command(fmt.Sprintf("kustomize%s", kustomizeVersion), "build", filepath.Join(diffBasePath, "overlays", "downstreams", downstreamName)).Output()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to run kustomize on base dir")
 	}

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -199,7 +199,7 @@ func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName stri
 
 	// we use the kustomize binary here...
 	cmd := exec.Command(fmt.Sprintf("kustomize%s", kotsKinds.KustomizeVersion()), "build", filepath.Join(archiveDir, "overlays", "downstreams", downstreamName))
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to run kustomize")
 	}

--- a/pkg/handlers/rendered_contents.go
+++ b/pkg/handlers/rendered_contents.go
@@ -84,7 +84,7 @@ func GetAppRenderedContents(w http.ResponseWriter, r *http.Request) {
 		kustomizeBuildTarget = filepath.Join(archivePath, "overlays", "downstreams", downstreamName)
 	}
 
-	archiveOutput, err := exec.Command(fmt.Sprintf("kustomize%s", kotsKinds.KustomizeVersion()), "build", kustomizeBuildTarget).CombinedOutput()
+	archiveOutput, err := exec.Command(fmt.Sprintf("kustomize%s", kotsKinds.KustomizeVersion()), "build", kustomizeBuildTarget).Output()
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)


### PR DESCRIPTION
kustomize will sometimes print to stderr and still exit 0
with CombinedOutput this gets interleaved with the generated yaml, causing errors