### PR TITLE
allow overriding S3 region, skipping bucket create via env vars

### DIFF
--- a/api/src/server/params.ts
+++ b/api/src/server/params.ts
@@ -23,6 +23,8 @@ export class Params {
   readonly s3AccessKeyId: string;
   readonly s3SecretAccessKey: string;
   readonly s3BucketEndpoint: string;
+  readonly s3Region: string;
+  readonly s3SkipEnsureBucket: boolean;
   readonly apiAdvertiseEndpoint: string;
   readonly graphqlPremEndpoint: string;
   readonly segmentioAnalyticsKey: string;
@@ -48,6 +50,8 @@ export class Params {
     s3AccessKeyId,
     s3SecretAccessKey,
     s3BucketEndpoint,
+    s3Region,
+    s3SkipEnsureBucket,
     apiAdvertiseEndpoint,
     graphqlPremEndpoint,
     segmentioAnalyticsKey,
@@ -72,6 +76,8 @@ export class Params {
     this.s3AccessKeyId = s3AccessKeyId;
     this.s3SecretAccessKey = s3SecretAccessKey;
     this.s3BucketEndpoint = s3BucketEndpoint;
+    this.s3Region = s3Region;
+    this.s3SkipEnsureBucket = s3SkipEnsureBucket;
     this.apiAdvertiseEndpoint = apiAdvertiseEndpoint;
     this.graphqlPremEndpoint = graphqlPremEndpoint;
     this.segmentioAnalyticsKey = segmentioAnalyticsKey;
@@ -104,6 +110,8 @@ export class Params {
       s3AccessKeyId: params["S3_ACCESS_KEY_ID"],
       s3SecretAccessKey: params["S3_SECRET_ACCESS_KEY"],
       s3BucketEndpoint: params["S3_BUCKET_ENDPOINT"],
+      s3Region: process.env["S3_REGION"] || "us-east-1",
+      s3SkipEnsureBucket: process.env["S3_SKIP_ENSURE_BUCKET"] === "1",
       apiAdvertiseEndpoint: process.env["SHIP_API_ADVERTISE_ENDPOINT"],
       graphqlPremEndpoint: params["GRAPHQL_PREM_ENDPOINT"],
       segmentioAnalyticsKey: params["SEGMENTIO_ANALYTICS_WRITE_KEY"],
@@ -140,7 +148,7 @@ export class Params {
       GRAPHQL_PREM_ENDPOINT: "/graphql/prem_endpoint",
       SEGMENTIO_ANALYTICS_WRITE_KEY: "/shipcloud/segmentio/analytics_write_key",
       ENABLE_KURL: "",
-    }
+    };
     return await lookupParams(paramLookup);
   }
 }

--- a/api/src/server/server.ts
+++ b/api/src/server/server.ts
@@ -225,12 +225,15 @@ export class Server extends ServerLoader {
   async $onReady() {
     this.expressApp.get("*", (req: Request, res: Response) => res.sendStatus(404));
 
-    if (process.env["S3_BUCKET_NAME"] === "ship-pacts") {
+    const params = await Params.getParams();
+
+    if (params.shipOutputBucket === "ship-pacts") {
       logger.info({msg: "Not creating bucket because the desired name is ship-pacts. Consider using a different bucket name to make this work."});
+    } else if (params.s3SkipEnsureBucket) {
+      logger.info({msg: "Not creating bucket because S3_SKIP_ENSURE_BUCKET was set"});
     } else {
       logger.info({msg: "Ensuring bucket exists..."});
-      const params = await Params.getParams();
-      await ensureBucket(params, params.shipOutputBucket);
+      await ensureBucket(params);
     }
 
     logger.info({msg: "Server started..."});

--- a/api/src/util/s3.ts
+++ b/api/src/util/s3.ts
@@ -24,7 +24,7 @@ export function getS3(params: Params): AWS.S3 {
   return new AWS.S3(s3Params);
 };
 
-export async function ensureBucket(params: Params, bucketName: string): Promise<boolean> {
+export async function ensureBucket(params: Params): Promise<boolean> {
   const parsedEndpoint = url.parse(params.s3Endpoint);
   const minioClient = new Minio.Client({
     endPoint: parsedEndpoint.hostname,
@@ -35,7 +35,7 @@ export async function ensureBucket(params: Params, bucketName: string): Promise<
   });
 
   return new Promise((resolve, reject) => {
-    minioClient.makeBucket(params.shipOutputBucket, "us-east-1", function(err) {
+    minioClient.makeBucket(params.shipOutputBucket, params.s3Region, function(err) {
       if (err) {
         if (err.toString().indexOf("Your previous request to create the named bucket succeeded and you already own it") !== -1) {
           resolve(true);

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -13,10 +13,15 @@ func GetConfig() *aws.Config {
 		forcePathStyle = true
 	}
 
+	region := os.Getenv("S3_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+
 	s3Config := &aws.Config{
 		Credentials:      credentials.NewStaticCredentials(os.Getenv("S3_ACCESS_KEY_ID"), os.Getenv("S3_SECRET_ACCESS_KEY"), ""),
 		Endpoint:         aws.String(os.Getenv("S3_ENDPOINT")),
-		Region:           aws.String("us-east-1"),
+		Region:           aws.String(region),
 		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(forcePathStyle),
 	}

--- a/pkg/version/archive.go
+++ b/pkg/version/archive.go
@@ -44,6 +44,10 @@ func CreateAppVersionArchive(appID string, sequence int64, archivePath string) e
 
 	bucket := aws.String(os.Getenv("S3_BUCKET_NAME"))
 	key := aws.String(fmt.Sprintf("%s/%d.tar.gz", appID, sequence))
+	region := os.Getenv("S3_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
 
 	newSession := awssession.New(kotss3.GetConfig())
 

--- a/pkg/version/archive.go
+++ b/pkg/version/archive.go
@@ -44,10 +44,6 @@ func CreateAppVersionArchive(appID string, sequence int64, archivePath string) e
 
 	bucket := aws.String(os.Getenv("S3_BUCKET_NAME"))
 	key := aws.String(fmt.Sprintf("%s/%d.tar.gz", appID, sequence))
-	region := os.Getenv("S3_REGION")
-	if region == "" {
-		region = "us-east-1"
-	}
 
 	newSession := awssession.New(kotss3.GetConfig())
 


### PR DESCRIPTION
- We hardcode s3 region to `us-east-1` everywhere, but I wanted to make it configurable via an env var.
- we always create a bucket unless the bucket name is `ship-pacts`, but I wanted to make an env var to force skipping creation regardless of bucket name

See also https://github.com/replicatedhq/kots/issues/457 and https://github.com/replicatedhq/kots/pull/474

It's unclear to me if we can point a minio client at a regular S3 bucket, but we seem to do it for ship-pacts. At the very least this feels quite safe and a value-add long term.