### PR TITLE
handle objects with the same groupversionkind+name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/replicatedhq/kots v1.15.1
+	github.com/replicatedhq/kots v1.15.2-0.20200505172613-3ed849a1e15c
 	github.com/replicatedhq/kotsadm/operator v0.0.0-20200501000547-b1b5fb425e17 // indirect
 	github.com/replicatedhq/troubleshoot v0.9.31
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.sum
+++ b/go.sum
@@ -752,6 +752,8 @@ github.com/replicatedhq/kots v1.15.0 h1:Vo4GLK5fG7aXL9mDXeLsvYJeK5ijcIW7oTKFiNah
 github.com/replicatedhq/kots v1.15.0/go.mod h1:8mbam1nJv/DzA7809Tx0kEL4IBhIYqtzACMsM+eKIOw=
 github.com/replicatedhq/kots v1.15.1 h1:uEOzQrC9/VYsdNtULLHaenZ+BpKxQ+j1jLQzc/zLC7M=
 github.com/replicatedhq/kots v1.15.1/go.mod h1:8mbam1nJv/DzA7809Tx0kEL4IBhIYqtzACMsM+eKIOw=
+github.com/replicatedhq/kots v1.15.2-0.20200505172613-3ed849a1e15c h1:Gl+lw4sUxus4jUli8JvjIvX3mOmE1H2Kuta72GP82VA=
+github.com/replicatedhq/kots v1.15.2-0.20200505172613-3ed849a1e15c/go.mod h1:8mbam1nJv/DzA7809Tx0kEL4IBhIYqtzACMsM+eKIOw=
 github.com/replicatedhq/kotsadm/operator v0.0.0-20200501000547-b1b5fb425e17 h1:iSEujts7eKt+d/LLAuvATUt3jf8WCOZhSJ/gaynUmiU=
 github.com/replicatedhq/kotsadm/operator v0.0.0-20200501000547-b1b5fb425e17/go.mod h1:6GfvQbCeR02BhpcEcaPTN2J62FA3dnzxRQviEdakB/0=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200306230415-b6d377a48a56 h1:W4lzQxpdUPFVTjs6zCDFGyAbPfow28zbFU65QCQf+SY=


### PR DESCRIPTION
if they are in different namespaces, they are not the same object

specifically, this updates the kots import to include https://github.com/replicatedhq/kots/pull/494, which was deduplicating objects by GVK only