### PR TITLE
Support detection of the Velero helm chart

### DIFF
--- a/pkg/supportbundle/backup.go
+++ b/pkg/supportbundle/backup.go
@@ -58,6 +58,7 @@ func CreateBundleForBackup(appID string, backupName string, backupNamespace stri
 				Selector: []string{
 					"component=velero",
 					"deploy=velero",
+					"app.kubernetes.io/name=velero",
 				},
 			},
 		},
@@ -76,6 +77,7 @@ func CreateBundleForBackup(appID string, backupName string, backupNamespace stri
 				Selector: []string{
 					"component=velero",
 					"name=restic",
+					"app.kubernetes.io/name=velero",
 				},
 			},
 		},


### PR DESCRIPTION
This fixes replicatedhq/kots#539

The helm chart uses different label selectors.

There's still a chance this won't work in some cases. There are no static label selector or annotations in this deployment.  But KOTS supports "standard" installations of velero, and this extends support for the velero helm chart installation method.